### PR TITLE
fix: correct FP2 connectivity binary sensor state

### DIFF
--- a/custom_components/ha_aqara_devices/fp2.py
+++ b/custom_components/ha_aqara_devices/fp2.py
@@ -43,7 +43,7 @@ FP2_BINARY_SENSORS_DEF = [
         "key": "device_offline_status",
         "device_class": BinarySensorDeviceClass.CONNECTIVITY,
         "icon": "mdi:lan-connect",
-        "on_values": {"0"},
+        "on_values": {"1"},
     },
     *FP2_ZONE_BINARY_SENSORS_DEF,
 ]

--- a/custom_components/ha_aqara_devices/manifest.json
+++ b/custom_components/ha_aqara_devices/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "pycryptodome>=3.20.0"
   ],
-    "version": "0.1.0"
+    "version": "0.2.1"
 }


### PR DESCRIPTION
## Summary
- fix FP2 connectivity binary sensor mapping to match Aqara `device_offline_status` semantics (`0` offline, `1` online)
- ensure `binary_sensor.*_connectivity` reports connected state correctly when FP2 devices are online
- keep the change scoped to the FP2 binary sensor definition only

## Testing
- `python3 -m compileall custom_components/ha_aqara_devices`