### PR TITLE
fix: value_type coercion bug and smart polling toggle

### DIFF
--- a/custom_components/ha_aqara_devices/fp2.py
+++ b/custom_components/ha_aqara_devices/fp2.py
@@ -171,6 +171,7 @@ FP2_STATUS_SENSORS_DEF = [
         "api": "14.49.85",
         "poll_group": "slow",
         "icon": "mdi:cog",
+        "value_type": "str",
         "value_map": FP2_MODE_LABELS,
     },
     {
@@ -178,6 +179,7 @@ FP2_STATUS_SENSORS_DEF = [
         "key": "view_zoom",
         "poll_group": "slow",
         "icon": "mdi:magnify-scan",
+        "value_type": "str",
         "value_map": FP2_VIEW_MODES,
     },
     {
@@ -186,6 +188,7 @@ FP2_STATUS_SENSORS_DEF = [
         "api": "14.57.85",
         "poll_group": "slow",
         "icon": "mdi:wall",
+        "value_type": "str",
         "value_map": FP2_MOUNTING_POSITIONS,
     },
     {
@@ -194,6 +197,7 @@ FP2_STATUS_SENSORS_DEF = [
         "api": "13.35.85",
         "poll_group": "slow",
         "icon": "mdi:rotate-3d-variant",
+        "value_type": "str",
         "value_map": FP2_INSTALLATION_ANGLES,
     },
     {
@@ -202,6 +206,7 @@ FP2_STATUS_SENSORS_DEF = [
         "api": "13.70.85",
         "poll_group": "slow",
         "icon": "mdi:axis-arrow",
+        "value_type": "str",
     },
 ]
 
@@ -212,6 +217,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "14.1.85",
         "poll_group": "slow",
         "icon": "mdi:account-eye",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["presence_detection_sens"],
     },
     {
@@ -220,6 +226,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "14.47.85",
         "poll_group": "slow",
         "icon": "mdi:signal-distance-variant",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["proximity_sensing_dist"],
     },
     {
@@ -228,6 +235,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "14.30.85",
         "poll_group": "slow",
         "icon": "mdi:human-female-fall",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["fall_detection_sens"],
     },
     {
@@ -236,6 +244,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "14.51.85",
         "poll_group": "slow",
         "icon": "mdi:axes-arrow",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["reverse_coordinate_dir"],
     },
     {
@@ -244,6 +253,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "14.55.85",
         "poll_group": "slow",
         "icon": "mdi:axis-z-arrow",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["detection_dir"],
     },
     {
@@ -252,6 +262,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "4.72.85",
         "poll_group": "slow",
         "icon": "mdi:account-search",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["ai_person_det"],
     },
     {
@@ -260,6 +271,7 @@ FP2_SETTINGS_SENSORS_DEF = [
         "api": "4.23.85",
         "poll_group": "slow",
         "icon": "mdi:white-balance-sunny",
+        "value_type": "str",
         "value_map": FP2_SETTING_VALUE_MAPS["anti_light_poll"],
     },
 ]

--- a/custom_components/ha_aqara_devices/push.py
+++ b/custom_components/ha_aqara_devices/push.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from datetime import timedelta
 import json
 import logging
 import time
@@ -9,6 +10,8 @@ from typing import Any
 
 from aiohttp import ClientSession, ClientTimeout
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import BRIDGE_SANITY_INTERVAL_SECONDS
 
 from .api import AqaraApi, AqaraAuthError
 from .bridge_specs import (
@@ -86,6 +89,25 @@ class AqaraBridgePushManager:
 
     def _subscription_resource_count(self) -> int:
         return sum(len(subscription["resourceIds"]) for subscription in self._subscriptions)
+
+    def _all_coordinators(self):
+        """Yield every coordinator managed by this push manager."""
+        yield from self._camera_coordinators.values()
+        yield from self._m3_coordinators.values()
+        for groups in self._presence_coordinators.values():
+            yield from groups.values()
+
+    def _set_polling_enabled(self, enabled: bool) -> None:
+        """Toggle coordinator polling based on bridge SSE health.
+
+        When the bridge SSE stream is connected, polling is disabled because
+        push delivers all resource updates in real time.  When SSE drops,
+        polling is re-enabled as an automatic fallback.
+        """
+        interval = timedelta(seconds=BRIDGE_SANITY_INTERVAL_SECONDS) if enabled else None
+        for coordinator in self._all_coordinators():
+            coordinator.update_interval = interval
+        _LOGGER.debug("Coordinator polling %s", "enabled" if enabled else "disabled")
 
     async def async_start(self) -> None:
         if self._started:
@@ -190,6 +212,9 @@ class AqaraBridgePushManager:
                     break
                 _LOGGER.warning("Aqara bridge SSE connection failed: %s", err)
 
+            # SSE disconnected - re-enable polling as fallback
+            self._set_polling_enabled(True)
+
             if self._stop_event.is_set():
                 break
             await asyncio.sleep(reconnect_delay)
@@ -208,6 +233,7 @@ class AqaraBridgePushManager:
                 raise RuntimeError(f"Aqara bridge events connection failed ({response.status}): {body}")
 
             self._connected_event.set()
+            self._set_polling_enabled(False)
             _LOGGER.info("Connected to Aqara bridge SSE stream at %s", url)
 
             event_name: str | None = None


### PR DESCRIPTION
Fixes #34

## Context

Aqara's free developer tier has a 100k monthly call limit. Both API requests and message pushes count towards this limit. With a single FP2 sensor over roughly 22 hours we observed 1,333 API requests + 2,420 message pushes = 3,753 total calls. Extrapolated to a full month that is around 80,000 calls for one sensor, close to the free limit. The 1,333 API requests were entirely redundant because the bridge SSE push was already delivering the same data.

## Fix

### value_type coercion

12 FP2 specs (5 status sensors, 7 settings sensors) had no `value_type` set. Without it, `coerce_spec_value` falls through to `_to01()` which converts any value to 0 or 1. This breaks multi-value fields like sensitivity ("1"=low, "2"=medium, "3"=high) or operating mode ("3"=zone_detection, "5"=fall_detection) because e.g. "2" becomes 0 instead of staying "2" for `value_map` lookup.

Added `value_type: "str"` to all affected specs so the raw string value is preserved.

### Smart polling

The coordinators poll every 300s even when the bridge SSE stream is connected and delivering all resource updates in real time. This wastes around 1,400 API calls per day per device for data that push already covers.

Polling is now disabled when SSE connects and re-enabled automatically when SSE disconnects, so it acts as a true fallback instead of running unconditionally. The initial poll at startup still happens to populate current state before the bridge connects.

This cuts monthly usage from around 80,000 to around 36,000 per sensor (push only), leaving room for multiple devices on the free tier.