### PR TITLE
feat: add Aqara Hub M200 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![HACS Action](https://github.com/Darkdragon14/ha-aqara-devices/actions/workflows/hacs_action.yml/badge.svg)](https://github.com/Darkdragon14/ha-aqara-devices/actions/workflows/hacs_action.yml)
 [![release](https://img.shields.io/github/v/release/Darkdragon14/ha-aqara-devices.svg)](https://github.com/Darkdragon14/ha-aqara-devices/releases)
 
-`Aqara Devices (Hub G3, Hub M3, FP2 and FP300)` connects Aqara Hub G3, Hub M3, Presence Sensor FP2, and Presence Multi-Sensor FP300 to Home Assistant with Aqara Open API v3 and `aqara-rocketmq-bridge`.
+`Aqara Devices` connects Aqara Hub G3, Hub M3, Hub M200, Presence Sensor FP2, and Presence Multi-Sensor FP300 to Home Assistant with Aqara Open API v3 and `aqara-rocketmq-bridge`.
 
 Instead of relying only on periodic polling, the integration now uses Aqara Message Push -> RocketMQ -> bridge -> Server-Sent Events (SSE) so Home Assistant receives live updates while the integration keeps Aqara authentication, token refresh, and resource subscriptions in sync.
 
@@ -120,6 +120,14 @@ After the first step, Aqara sends a verification code to your email address or p
 | `sensor` | Temperature, Humidity |
 | `select` | Gateway Language, Alarm Ringtone, Doorbell Ringtone |
 
+### Hub M200
+
+| Platform | Entities |
+| --- | --- |
+| `binary_sensor` | AC On/Off Status |
+| `number` | Alert Volume, System Volume, Alert Duration |
+| `select` | Gateway Language, Alert Ringtone, AC Mode |
+
 ### Presence Sensor FP2
 
 | Platform | Entities |
@@ -134,7 +142,7 @@ After the first step, Aqara sends a verification code to your email address or p
 | `binary_sensor` | Presence |
 | `sensor` | Temperature, Humidity, Illuminance, Battery |
 
-Each discovered G3, M3, FP2, or FP300 device in your Aqara account gets its own entities and device metadata inside Home Assistant.
+Each discovered G3, M3, M200, FP2, or FP300 device in your Aqara account gets its own entities and device metadata inside Home Assistant.
 
 ## Need Help?
 

--- a/custom_components/ha_aqara_devices/__init__.py
+++ b/custom_components/ha_aqara_devices/__init__.py
@@ -30,6 +30,7 @@ from .const import (
     G410_MODELS,
     G3_MODELS,
     M100_MODELS,
+    M200_MODELS,
     M3_MODELS,
     PLATFORMS,
     PRESENCE_MODELS,
@@ -259,6 +260,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         G410_STATE_SPECS,
         G3_STATE_SPECS,
         M100_STATE_SPECS,
+        M200_STATE_SPECS,
         M3_STATE_SPECS,
         build_active_subscriptions,
     )
@@ -301,10 +303,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         g410_doorbells = [device for device in devices if device.get("model") in G410_MODELS]
         hubs_m3 = [device for device in devices if device.get("model") in M3_MODELS]
         hubs_m100 = [device for device in devices if device.get("model") in M100_MODELS]
+        hubs_m200 = [device for device in devices if device.get("model") in M200_MODELS]
         presence_devices = [device for device in devices if device.get("model") in PRESENCE_MODELS]
 
-        if not cameras and not g2h_pro_cameras and not g410_doorbells and not hubs_m3 and not hubs_m100 and not presence_devices:
-            raise ConfigEntryNotReady("No Aqara G2H Pro, G3, G410, M3, M100, FP2, or FP300 devices found")
+        if not cameras and not g2h_pro_cameras and not g410_doorbells and not hubs_m3 and not hubs_m100 and not hubs_m200 and not presence_devices:
+            raise ConfigEntryNotReady("No Aqara G2H Pro, G3, G410, M3, M100, M200, FP2, or FP300 devices found")
 
     except (ConfigEntryAuthFailed, AqaraAuthError) as err:
         if isinstance(err, AqaraAuthError):
@@ -332,6 +335,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     m3_coordinators = _setup_device_state_coordinators(hass, api, hubs_m3, "hub-m3-state", M3_STATE_SPECS)
     m100_coordinators = _setup_device_state_coordinators(hass, api, hubs_m100, "hub-m100-state", M100_STATE_SPECS)
+    m200_coordinators = _setup_device_state_coordinators(hass, api, hubs_m200, "hub-m200-state", M200_STATE_SPECS)
     presence_coordinators = _setup_presence_coordinators(hass, api, presence_devices)
 
     bridge_url = _entry_bridge_value(entry, CONF_BRIDGE_URL, DEFAULT_BRIDGE_URL)
@@ -346,12 +350,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "g410_doorbells": g410_doorbells,
         "hubs_m3": hubs_m3,
         "hubs_m100": hubs_m100,
+        "hubs_m200": hubs_m200,
         "presence_devices": presence_devices,
         "camera_coordinators": camera_coordinators,
         "g2h_pro_coordinators": g2h_pro_coordinators,
         "g410_coordinators": g410_coordinators,
         "m3_coordinators": m3_coordinators,
         "m100_coordinators": m100_coordinators,
+        "m200_coordinators": m200_coordinators,
         "presence_coordinators": presence_coordinators,
         "bridge_manager": None,
         "bridge_task": None,
@@ -374,6 +380,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         g410_doorbells,
         hubs_m3,
         hubs_m100,
+        hubs_m200,
         presence_devices,
     )
     entry_data["active_subscriptions"] = active_subscriptions
@@ -389,12 +396,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         g410_doorbells,
         hubs_m3,
         hubs_m100,
+        hubs_m200,
         presence_devices,
         camera_coordinators,
         g2h_pro_coordinators,
         g410_coordinators,
         m3_coordinators,
         m100_coordinators,
+        m200_coordinators,
         presence_coordinators,
         active_subscriptions,
     )

--- a/custom_components/ha_aqara_devices/binary_sensor.py
+++ b/custom_components/ha_aqara_devices/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .binary_sensors import ALL_BINARY_SENSORS_DEF, G410_BINARY_SENSORS_DEF, M100_BINARY_SENSORS_DEF, M3_BINARY_SENSORS_DEF
+from .binary_sensors import ALL_BINARY_SENSORS_DEF, G410_BINARY_SENSORS_DEF, M100_BINARY_SENSORS_DEF, M200_BINARY_SENSORS_DEF, M3_BINARY_SENSORS_DEF
 from .const import (
     DOMAIN,
     FP2_DEVICE_LABEL,
@@ -24,6 +24,7 @@ from .const import (
     G3_DEVICE_LABEL,
     G3_MODEL,
     M100_DEVICE_LABEL,
+    M200_DEVICE_LABEL,
     M3_DEVICE_LABEL,
 )
 from .device_info import build_device_info
@@ -40,11 +41,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     g410_doorbells: list[dict] = data.get("g410_doorbells", [])
     hubs_m3: list[dict] = data.get("hubs_m3", [])
     hubs_m100: list[dict] = data.get("hubs_m100", [])
+    hubs_m200: list[dict] = data.get("hubs_m200", [])
     presence_devices: list[dict] = data.get("presence_devices", [])
     camera_coordinators: dict[str, DataUpdateCoordinator] = data.get("camera_coordinators", {})
     g410_coordinators: dict[str, DataUpdateCoordinator] = data.get("g410_coordinators", {})
     m3_coordinators: dict[str, DataUpdateCoordinator] = data.get("m3_coordinators", {})
     m100_coordinators: dict[str, DataUpdateCoordinator] = data.get("m100_coordinators", {})
+    m200_coordinators: dict[str, DataUpdateCoordinator] = data.get("m200_coordinators", {})
     presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]] = data.get("presence_coordinators", {})
 
     entities = []
@@ -130,6 +133,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     binary_sensor_def,
                     model,
                     M100_DEVICE_LABEL,
+                )
+            )
+
+    for hub in hubs_m200:
+        did = hub["did"]
+        name = hub["deviceName"]
+        model = hub["model"]
+        coordinator = m200_coordinators.get(did)
+        if coordinator is None:
+            continue
+
+        for binary_sensor_def in M200_BINARY_SENSORS_DEF:
+            entities.append(
+                AqaraBinarySensor(
+                    coordinator,
+                    did,
+                    name,
+                    api,
+                    binary_sensor_def,
+                    model,
+                    M200_DEVICE_LABEL,
                 )
             )
 

--- a/custom_components/ha_aqara_devices/binary_sensors.py
+++ b/custom_components/ha_aqara_devices/binary_sensors.py
@@ -92,6 +92,19 @@ M100_BINARY_SENSORS_DEF = [
     M100_DEVICE_ONLINE_STATUS,
 ]
 
+M200_AC_ON_OFF_STATUS = {
+    "name": "AC On/Off Status",
+    "icon": "mdi:air-conditioner",
+    "inApp": "on_off_status",
+    "api": "3.1.85",
+    "device_class": "power",
+    "value_type": "bool",
+}
+
+M200_BINARY_SENSORS_DEF = [
+    M200_AC_ON_OFF_STATUS,
+]
+
 G410_DOORBELL_RING = {
     "name": "Doorbell Ring",
     "icon": "mdi:doorbell-video",

--- a/custom_components/ha_aqara_devices/binary_sensors.py
+++ b/custom_components/ha_aqara_devices/binary_sensors.py
@@ -91,6 +91,7 @@ M100_BINARY_SENSORS_DEF = [
 
 M200_AC_ON_OFF_STATUS = {
     "name": "AC On/Off Status",
+    "translation_key": "ac_on_off_status",
     "icon": "mdi:air-conditioner",
     "inApp": "on_off_status",
     "api": "3.1.85",

--- a/custom_components/ha_aqara_devices/bridge_specs.py
+++ b/custom_components/ha_aqara_devices/bridge_specs.py
@@ -8,13 +8,14 @@ from .binary_sensors import (
     GESTURE_RESOURCE_ID,
     GESTURE_SENSORS,
     M100_BINARY_SENSORS_DEF,
+    M200_BINARY_SENSORS_DEF,
     M3_BINARY_SENSORS_DEF,
 )
 from .const import FP2_MODEL, FP300_MODEL
 from .fp2 import FP2_BINARY_SENSORS_DEF, FP2_SENSOR_SPECS
 from .fp300 import FP300_BINARY_SENSORS_DEF, FP300_SENSOR_SPECS
-from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, M100_NUMBERS_DEF, M3_NUMBERS_DEF
-from .selects import G410_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
+from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, M100_NUMBERS_DEF, M200_NUMBERS_DEF, M3_NUMBERS_DEF
+from .selects import G410_SELECTS_DEF, M100_SELECTS_DEF, M200_SELECTS_DEF, M3_SELECTS_DEF
 from .sensors import G410_SENSORS_DEF, M100_SENSORS_DEF, M3_SENSORS_DEF
 from .switches import ALL_SWITCHES_DEF, G2H_PRO_SWITCHES_DEF, G410_SWITCHES_DEF, M100_SWITCHES_DEF
 
@@ -131,6 +132,15 @@ M100_RESOURCE_SPEC_MAP = build_api_spec_map(M100_STATE_SPECS)
 M100_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(M100_STATE_SPECS)
 
 
+M200_STATE_SPECS = [
+    *M200_BINARY_SENSORS_DEF,
+    *M200_NUMBERS_DEF,
+    *M200_SELECTS_DEF,
+]
+M200_RESOURCE_SPEC_MAP = build_api_spec_map(M200_STATE_SPECS)
+M200_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(M200_STATE_SPECS)
+
+
 FP2_STATE_SPECS = [
     *FP2_BINARY_SENSORS_DEF,
     *FP2_SENSOR_SPECS,
@@ -227,6 +237,13 @@ def _collect_m100_resources(enabled_unique_ids: set[str], did: str) -> list[str]
     return list(resource_ids)
 
 
+def _collect_m200_resources(enabled_unique_ids: set[str], did: str) -> list[str]:
+    resource_ids: dict[str, None] = {}
+    for spec in M200_STATE_SPECS:
+        _append_resource_if_enabled(resource_ids, enabled_unique_ids, f"{did}_{spec['inApp']}", spec)
+    return list(resource_ids)
+
+
 def _collect_presence_resources(
     enabled_unique_ids: set[str],
     did: str,
@@ -248,6 +265,7 @@ def build_active_subscriptions(
     g410_doorbells: list[dict[str, Any]],
     hubs_m3: list[dict[str, Any]],
     hubs_m100: list[dict[str, Any]],
+    hubs_m200: list[dict[str, Any]],
     presence_devices: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     subscriptions: list[dict[str, Any]] = []
@@ -279,6 +297,12 @@ def build_active_subscriptions(
     for hub in hubs_m100:
         did = str(hub["did"])
         resource_ids = _collect_m100_resources(enabled_unique_ids, did)
+        if resource_ids:
+            subscriptions.append({"subjectId": did, "resourceIds": resource_ids})
+
+    for hub in hubs_m200:
+        did = str(hub["did"])
+        resource_ids = _collect_m200_resources(enabled_unique_ids, did)
         if resource_ids:
             subscriptions.append({"subjectId": did, "resourceIds": resource_ids})
 

--- a/custom_components/ha_aqara_devices/const.py
+++ b/custom_components/ha_aqara_devices/const.py
@@ -39,6 +39,7 @@ G2H_PRO_MODELS = {"lumi.camera.agl001", "lumi.camera.acn003"}
 G410_MODELS = {"lumi.camera.acn017", "lumi.camera.agl006"}
 M3_MODELS = {"lumi.gateway.acn012", "lumi.gateway.agl004"}
 M100_MODELS = {"lumi.gateway.agl008", "lumi.gateway.agl010"}
+M200_MODELS = {"lumi.gateway.agl011"}
 PRESENCE_MODELS = {FP2_MODEL, FP300_MODEL}
 
 G3_DEVICE_LABEL = "Aqara G3"
@@ -46,6 +47,7 @@ G2H_PRO_DEVICE_LABEL = "Aqara Camera Hub G2H Pro"
 G410_DEVICE_LABEL = "Aqara Doorbell G410"
 M3_DEVICE_LABEL = "Aqara Hub M3"
 M100_DEVICE_LABEL = "Aqara Hub M100"
+M200_DEVICE_LABEL = "Aqara Hub M200"
 FP2_DEVICE_LABEL = "Aqara FP2"
 FP300_DEVICE_LABEL = "Presence Multi-Sensor FP300"
 

--- a/custom_components/ha_aqara_devices/number.py
+++ b/custom_components/ha_aqara_devices/number.py
@@ -11,8 +11,8 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.number import NumberEntity
 
-from .const import DOMAIN, G2H_PRO_DEVICE_LABEL, G410_DEVICE_LABEL, G3_MODEL, G3_DEVICE_LABEL, M100_DEVICE_LABEL, M3_DEVICE_LABEL
-from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, M100_NUMBERS_DEF, M3_NUMBERS_DEF
+from .const import DOMAIN, G2H_PRO_DEVICE_LABEL, G410_DEVICE_LABEL, G3_MODEL, G3_DEVICE_LABEL, M100_DEVICE_LABEL, M200_DEVICE_LABEL, M3_DEVICE_LABEL
+from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, M100_NUMBERS_DEF, M200_NUMBERS_DEF, M3_NUMBERS_DEF
 from .api import AqaraApi
 from .device_info import build_device_info
 
@@ -26,11 +26,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     g410_doorbells: list[dict] = data.get("g410_doorbells", [])
     hubs_m3: list[dict] = data.get("hubs_m3", [])
     hubs_m100: list[dict] = data.get("hubs_m100", [])
+    hubs_m200: list[dict] = data.get("hubs_m200", [])
     camera_coordinators: dict[str, DataUpdateCoordinator] = data.get("camera_coordinators", {})
     g2h_pro_coordinators: dict[str, DataUpdateCoordinator] = data.get("g2h_pro_coordinators", {})
     g410_coordinators: dict[str, DataUpdateCoordinator] = data.get("g410_coordinators", {})
     m3_coordinators: dict[str, DataUpdateCoordinator] = data.get("m3_coordinators", {})
     m100_coordinators: dict[str, DataUpdateCoordinator] = data.get("m100_coordinators", {})
+    m200_coordinators: dict[str, DataUpdateCoordinator] = data.get("m200_coordinators", {})
 
     entities = []
 
@@ -93,7 +95,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         for number_def in M100_NUMBERS_DEF:
             number = AqaraNumber(coordinator, api, did, name, number_def, model, M100_DEVICE_LABEL)
             entities.append(number)
-         
+
+    for hub in hubs_m200:
+        did = hub["did"]
+        name = hub["deviceName"]
+        model = hub["model"]
+        coordinator = m200_coordinators.get(did)
+        if coordinator is None:
+            continue
+
+        for number_def in M200_NUMBERS_DEF:
+            number = AqaraNumber(coordinator, api, did, name, number_def, model, M200_DEVICE_LABEL)
+            entities.append(number)
+
     async_add_entities(entities)
 
 class AqaraNumber(CoordinatorEntity, NumberEntity):

--- a/custom_components/ha_aqara_devices/numbers.py
+++ b/custom_components/ha_aqara_devices/numbers.py
@@ -151,6 +151,45 @@ M100_NUMBERS_DEF = [
     M100_ARMING_DELAY_TIME,
 ]
 
+M200_ALERT_VOLUME = {
+    "name": "Alert Volume",
+    "icon": "mdi:bell-ring",
+    "inApp": "alarm_bell_volume",
+    "api": "14.1.1000",
+    "min": 0,
+    "max": 100,
+    "step": 1,
+    "type": "integer",
+}
+
+M200_SYSTEM_VOLUME = {
+    "name": "System Volume",
+    "icon": "mdi:volume-high",
+    "inApp": "system_volume",
+    "api": "14.11.85",
+    "min": 0,
+    "max": 100,
+    "step": 1,
+    "type": "integer",
+}
+
+M200_ALERT_DURATION = {
+    "name": "Alert Duration",
+    "icon": "mdi:timer",
+    "inApp": "alarm_time_length",
+    "api": "14.1.113",
+    "min": -1,
+    "max": 255,
+    "step": 1,
+    "type": "integer",
+}
+
+M200_NUMBERS_DEF = [
+    M200_ALERT_VOLUME,
+    M200_SYSTEM_VOLUME,
+    M200_ALERT_DURATION,
+]
+
 G2H_PRO_MUSIC_VOLUME = {
     "name": "Music Volume",
     "icon": "mdi:music-note",

--- a/custom_components/ha_aqara_devices/numbers.py
+++ b/custom_components/ha_aqara_devices/numbers.py
@@ -165,6 +165,7 @@ M100_NUMBERS_DEF = [
 
 M200_ALERT_VOLUME = {
     "name": "Alert Volume",
+    "translation_key": "alarm_volume",
     "icon": "mdi:bell-ring",
     "inApp": "alarm_bell_volume",
     "api": "14.1.1000",
@@ -176,6 +177,7 @@ M200_ALERT_VOLUME = {
 
 M200_SYSTEM_VOLUME = {
     "name": "System Volume",
+    "translation_key": "system_volume",
     "icon": "mdi:volume-high",
     "inApp": "system_volume",
     "api": "14.11.85",
@@ -187,6 +189,7 @@ M200_SYSTEM_VOLUME = {
 
 M200_ALERT_DURATION = {
     "name": "Alert Duration",
+    "translation_key": "alarm_duration",
     "icon": "mdi:timer",
     "inApp": "alarm_time_length",
     "api": "14.1.113",

--- a/custom_components/ha_aqara_devices/push.py
+++ b/custom_components/ha_aqara_devices/push.py
@@ -23,6 +23,7 @@ from .bridge_specs import (
     G3_GESTURE_VALUE_MAP,
     G3_RESOURCE_SPEC_MAP,
     M100_RESOURCE_SPEC_MAP,
+    M200_RESOURCE_SPEC_MAP,
     M3_RESOURCE_SPEC_MAP,
     coerce_spec_value,
     spec_state_key,
@@ -49,12 +50,14 @@ class AqaraBridgePushManager:
         g410_doorbells: list[dict[str, Any]],
         hubs_m3: list[dict[str, Any]],
         hubs_m100: list[dict[str, Any]],
+        hubs_m200: list[dict[str, Any]],
         presence_devices: list[dict[str, Any]],
         camera_coordinators: dict[str, DataUpdateCoordinator],
         g2h_pro_coordinators: dict[str, DataUpdateCoordinator],
         g410_coordinators: dict[str, DataUpdateCoordinator],
         m3_coordinators: dict[str, DataUpdateCoordinator],
         m100_coordinators: dict[str, DataUpdateCoordinator],
+        m200_coordinators: dict[str, DataUpdateCoordinator],
         presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]],
         subscriptions: list[dict[str, Any]],
     ) -> None:
@@ -68,18 +71,21 @@ class AqaraBridgePushManager:
         self._g410_coordinators = g410_coordinators
         self._m3_coordinators = m3_coordinators
         self._m100_coordinators = m100_coordinators
+        self._m200_coordinators = m200_coordinators
         self._presence_coordinators = presence_coordinators
         self._cameras = {device["did"]: device for device in cameras}
         self._g2h_pro_cameras = {device["did"]: device for device in g2h_pro_cameras}
         self._g410_doorbells = {device["did"]: device for device in g410_doorbells}
         self._hubs_m3 = {device["did"]: device for device in hubs_m3}
         self._hubs_m100 = {device["did"]: device for device in hubs_m100}
+        self._hubs_m200 = {device["did"]: device for device in hubs_m200}
         self._presence_devices = {device["did"]: device for device in presence_devices}
         self._camera_state: dict[str, dict[str, Any]] = {did: {} for did in self._cameras}
         self._g2h_pro_state: dict[str, dict[str, Any]] = {did: {} for did in self._g2h_pro_cameras}
         self._g410_state: dict[str, dict[str, Any]] = {did: {} for did in self._g410_doorbells}
         self._m3_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m3}
         self._m100_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m100}
+        self._m200_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m200}
         self._presence_state: dict[str, dict[str, dict[str, Any]]] = {
             did: {group: {} for group in coordinators}
             for did, coordinators in presence_coordinators.items()
@@ -119,6 +125,7 @@ class AqaraBridgePushManager:
         yield from self._g410_coordinators.values()
         yield from self._m3_coordinators.values()
         yield from self._m100_coordinators.values()
+        yield from self._m200_coordinators.values()
         for groups in self._presence_coordinators.values():
             yield from groups.values()
 
@@ -400,6 +407,20 @@ class AqaraBridgePushManager:
                 self._m100_coordinators,
                 self._m100_state,
                 M100_RESOURCE_SPEC_MAP,
+                pending_updates,
+                apply_scale=True,
+            )
+            return
+
+        if did in self._hubs_m200:
+            self._handle_shared_device_message(
+                payload_type,
+                did,
+                resource_id,
+                payload.get("value"),
+                self._m200_coordinators,
+                self._m200_state,
+                M200_RESOURCE_SPEC_MAP,
                 pending_updates,
                 apply_scale=True,
             )

--- a/custom_components/ha_aqara_devices/select.py
+++ b/custom_components/ha_aqara_devices/select.py
@@ -11,9 +11,9 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .api import AqaraApi
-from .const import DOMAIN, G410_DEVICE_LABEL, M100_DEVICE_LABEL, M3_DEVICE_LABEL
+from .const import DOMAIN, G410_DEVICE_LABEL, M100_DEVICE_LABEL, M200_DEVICE_LABEL, M3_DEVICE_LABEL
 from .device_info import build_device_info
-from .selects import G410_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
+from .selects import G410_SELECTS_DEF, M100_SELECTS_DEF, M200_SELECTS_DEF, M3_SELECTS_DEF
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,9 +24,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     g410_doorbells: list[dict] = data.get("g410_doorbells", [])
     hubs_m3: list[dict] = data.get("hubs_m3", [])
     hubs_m100: list[dict] = data.get("hubs_m100", [])
+    hubs_m200: list[dict] = data.get("hubs_m200", [])
     g410_coordinators: dict[str, DataUpdateCoordinator] = data.get("g410_coordinators", {})
     m3_coordinators: dict[str, DataUpdateCoordinator] = data.get("m3_coordinators", {})
     m100_coordinators: dict[str, DataUpdateCoordinator] = data.get("m100_coordinators", {})
+    m200_coordinators: dict[str, DataUpdateCoordinator] = data.get("m200_coordinators", {})
 
     entities: list[SelectEntity] = []
 
@@ -87,6 +89,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 select_def,
                 model,
                 M100_DEVICE_LABEL,
+            )
+            entities.append(select)
+
+    for hub in hubs_m200:
+        did = hub["did"]
+        name = hub["deviceName"]
+        model = hub["model"]
+        coordinator = m200_coordinators.get(did)
+        if coordinator is None:
+            continue
+
+        for select_def in M200_SELECTS_DEF:
+            select = AqaraSelect(
+                coordinator,
+                api,
+                did,
+                name,
+                select_def,
+                model,
+                M200_DEVICE_LABEL,
             )
             entities.append(select)
 

--- a/custom_components/ha_aqara_devices/selects.py
+++ b/custom_components/ha_aqara_devices/selects.py
@@ -110,12 +110,13 @@ M100_SELECTS_DEF = [
 
 M200_GATEWAY_LANGUAGE = {
     "name": "Gateway Language",
+    "translation_key": "gateway_language",
     "icon": "mdi:translate",
     "inApp": "gateway_language",
     "api": "14.10.85",
     "options": [
-        (1, "Chinese"),
-        (2, "English"),
+        (1, "chinese"),
+        (2, "english"),
     ],
     "value_type": "int",
     "default": None,
@@ -123,6 +124,7 @@ M200_GATEWAY_LANGUAGE = {
 
 M200_ALERT_RINGTONE = {
     "name": "Alert Ringtone",
+    "translation_key": "alarm_ringtone",
     "icon": "mdi:bell",
     "inApp": "alarm_bell_index",
     "api": "14.1.85",
@@ -133,15 +135,16 @@ M200_ALERT_RINGTONE = {
 
 M200_AC_MODE = {
     "name": "AC Mode",
+    "translation_key": "ac_mode",
     "icon": "mdi:air-conditioner",
     "inApp": "ac_mode",
     "api": "14.25.85",
     "options": [
-        (0, "Unconfigured Mode"),
-        (1, "Air Conditioner Plugged into Socket Mode"),
-        (2, "Air Conditioner Not Plugged into Socket Mode"),
-        (3, "Infrared Water Heater Mode"),
-        (4, "16A Socket Mode"),
+        (0, "unconfigured"),
+        (1, "air_conditioner_with_socket"),
+        (2, "air_conditioner_without_socket"),
+        (3, "infrared_water_heater"),
+        (4, "16a_socket"),
     ],
     "value_type": "int",
     "default": None,

--- a/custom_components/ha_aqara_devices/selects.py
+++ b/custom_components/ha_aqara_devices/selects.py
@@ -102,6 +102,51 @@ M100_SELECTS_DEF = [
     M100_DOORBELL_BELL_INDEX,
 ]
 
+M200_GATEWAY_LANGUAGE = {
+    "name": "Gateway Language",
+    "icon": "mdi:translate",
+    "inApp": "gateway_language",
+    "api": "14.10.85",
+    "options": [
+        (1, "Chinese"),
+        (2, "English"),
+    ],
+    "value_type": "int",
+    "default": None,
+}
+
+M200_ALERT_RINGTONE = {
+    "name": "Alert Ringtone",
+    "icon": "mdi:bell",
+    "inApp": "alarm_bell_index",
+    "api": "14.1.85",
+    "options": ALARM_BELL_INDEX_OPTIONS,
+    "value_type": "int",
+    "default": None,
+}
+
+M200_AC_MODE = {
+    "name": "AC Mode",
+    "icon": "mdi:air-conditioner",
+    "inApp": "ac_mode",
+    "api": "14.25.85",
+    "options": [
+        (0, "Unconfigured Mode"),
+        (1, "Air Conditioner Plugged into Socket Mode"),
+        (2, "Air Conditioner Not Plugged into Socket Mode"),
+        (3, "Infrared Water Heater Mode"),
+        (4, "16A Socket Mode"),
+    ],
+    "value_type": "int",
+    "default": None,
+}
+
+M200_SELECTS_DEF = [
+    M200_GATEWAY_LANGUAGE,
+    M200_ALERT_RINGTONE,
+    M200_AC_MODE,
+]
+
 G410_ALARM_BELL_INDEX = {
     "name": "Alarm Ringtone",
     "icon": "mdi:bell",

--- a/custom_components/ha_aqara_devices/translations/cz.json
+++ b/custom_components/ha_aqara_devices/translations/cz.json
@@ -98,6 +98,9 @@
             "doorbell_ring": {
                 "name": "Zvonek"
             },
+            "ac_on_off_status": {
+                "name": "Stav zapnutí/vypnutí klimatizace"
+            },
             "detection_area": {
                 "name": "Detekční zóna {index}"
             }
@@ -475,6 +478,16 @@
                     "radar_infrared": "Radar + Infračervený",
                     "radar_only": "Pouze radar",
                     "infrared_only": "Pouze infračervený"
+                }
+            },
+            "ac_mode": {
+                "name": "Režim klimatizace",
+                "state": {
+                    "unconfigured": "Nenakonfigurovaný režim",
+                    "air_conditioner_with_socket": "Klimatizace zapojená do zásuvky",
+                    "air_conditioner_without_socket": "Klimatizace nezapojená do zásuvky",
+                    "infrared_water_heater": "Režim infračerveného ohřívače vody",
+                    "16a_socket": "Režim zásuvky 16 A"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/de.json
+++ b/custom_components/ha_aqara_devices/translations/de.json
@@ -71,6 +71,9 @@
             "doorbell_ring": {
                 "name": "Türklingel"
             },
+            "ac_on_off_status": {
+                "name": "Klimaanlage Ein/Aus-Status"
+            },
             "detection_area": {
                 "name": "Erkennungsbereich {index}"
             }
@@ -448,6 +451,16 @@
                     "radar_infrared": "Radar + Infrarot",
                     "radar_only": "Nur Radar",
                     "infrared_only": "Nur Infrarot"
+                }
+            },
+            "ac_mode": {
+                "name": "Klimaanlagenmodus",
+                "state": {
+                    "unconfigured": "Nicht konfigurierter Modus",
+                    "air_conditioner_with_socket": "Klimaanlage an Steckdose angeschlossen",
+                    "air_conditioner_without_socket": "Klimaanlage nicht an Steckdose angeschlossen",
+                    "infrared_water_heater": "Infrarot-Warmwasserbereiter-Modus",
+                    "16a_socket": "16-A-Steckdosenmodus"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/en.json
+++ b/custom_components/ha_aqara_devices/translations/en.json
@@ -98,6 +98,9 @@
             "doorbell_ring": {
                 "name": "Doorbell Ring"
             },
+            "ac_on_off_status": {
+                "name": "AC On/Off Status"
+            },
             "detection_area": {
                 "name": "Detection Area {index}"
             }
@@ -475,6 +478,16 @@
                     "radar_infrared": "Radar + Infrared",
                     "radar_only": "Radar only",
                     "infrared_only": "Infrared only"
+                }
+            },
+            "ac_mode": {
+                "name": "AC Mode",
+                "state": {
+                    "unconfigured": "Unconfigured mode",
+                    "air_conditioner_with_socket": "Air conditioner plugged into socket mode",
+                    "air_conditioner_without_socket": "Air conditioner not plugged into socket mode",
+                    "infrared_water_heater": "Infrared water heater mode",
+                    "16a_socket": "16A socket mode"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/es.json
+++ b/custom_components/ha_aqara_devices/translations/es.json
@@ -71,6 +71,9 @@
             "doorbell_ring": {
                 "name": "Timbre"
             },
+            "ac_on_off_status": {
+                "name": "Estado de encendido/apagado del aire acondicionado"
+            },
             "detection_area": {
                 "name": "Área de detección {index}"
             }
@@ -448,6 +451,16 @@
                     "radar_infrared": "Radar + Infrarrojo",
                     "radar_only": "Solo radar",
                     "infrared_only": "Solo infrarrojo"
+                }
+            },
+            "ac_mode": {
+                "name": "Modo de aire acondicionado",
+                "state": {
+                    "unconfigured": "Modo no configurado",
+                    "air_conditioner_with_socket": "Aire acondicionado enchufado a la toma",
+                    "air_conditioner_without_socket": "Aire acondicionado no enchufado a la toma",
+                    "infrared_water_heater": "Modo calentador de agua por infrarrojos",
+                    "16a_socket": "Modo toma de 16 A"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/fr.json
+++ b/custom_components/ha_aqara_devices/translations/fr.json
@@ -98,6 +98,9 @@
             "doorbell_ring": {
                 "name": "Sonnette"
             },
+            "ac_on_off_status": {
+                "name": "État marche/arrêt de la climatisation"
+            },
             "detection_area": {
                 "name": "Zone de détection {index}"
             }
@@ -475,6 +478,16 @@
                     "radar_infrared": "Radar + Infrarouge",
                     "radar_only": "Radar uniquement",
                     "infrared_only": "Infrarouge uniquement"
+                }
+            },
+            "ac_mode": {
+                "name": "Mode climatisation",
+                "state": {
+                    "unconfigured": "Mode non configuré",
+                    "air_conditioner_with_socket": "Climatiseur branché sur prise",
+                    "air_conditioner_without_socket": "Climatiseur non branché sur prise",
+                    "infrared_water_heater": "Mode chauffe-eau infrarouge",
+                    "16a_socket": "Mode prise 16 A"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/hu.json
+++ b/custom_components/ha_aqara_devices/translations/hu.json
@@ -71,6 +71,9 @@
             "doorbell_ring": {
                 "name": "Csengetés"
             },
+            "ac_on_off_status": {
+                "name": "Légkondicionáló be/ki állapota"
+            },
             "detection_area": {
                 "name": "Érzékelési terület {index}"
             }
@@ -448,6 +451,16 @@
                     "radar_infrared": "Radar + Infravörös",
                     "radar_only": "Csak radar",
                     "infrared_only": "Csak infravörös"
+                }
+            },
+            "ac_mode": {
+                "name": "Légkondicionáló mód",
+                "state": {
+                    "unconfigured": "Nincs konfigurálva",
+                    "air_conditioner_with_socket": "Légkondicionáló aljzatba csatlakoztatva",
+                    "air_conditioner_without_socket": "Légkondicionáló nincs aljzatba csatlakoztatva",
+                    "infrared_water_heater": "Infravörös vízmelegítő mód",
+                    "16a_socket": "16 A aljzat mód"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/it.json
+++ b/custom_components/ha_aqara_devices/translations/it.json
@@ -71,6 +71,9 @@
             "doorbell_ring": {
                 "name": "Campanello"
             },
+            "ac_on_off_status": {
+                "name": "Stato acceso/spento climatizzatore"
+            },
             "detection_area": {
                 "name": "Area di rilevamento {index}"
             }
@@ -448,6 +451,16 @@
                     "radar_infrared": "Radar + Infrarosso",
                     "radar_only": "Solo radar",
                     "infrared_only": "Solo infrarosso"
+                }
+            },
+            "ac_mode": {
+                "name": "Modalità climatizzatore",
+                "state": {
+                    "unconfigured": "Modalità non configurata",
+                    "air_conditioner_with_socket": "Climatizzatore collegato alla presa",
+                    "air_conditioner_without_socket": "Climatizzatore non collegato alla presa",
+                    "infrared_water_heater": "Modalità scaldabagno a infrarossi",
+                    "16a_socket": "Modalità presa 16 A"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/nl.json
+++ b/custom_components/ha_aqara_devices/translations/nl.json
@@ -71,6 +71,9 @@
             "doorbell_ring": {
                 "name": "Deurbel"
             },
+            "ac_on_off_status": {
+                "name": "Airco aan/uit-status"
+            },
             "detection_area": {
                 "name": "Detectiezone {index}"
             }
@@ -448,6 +451,16 @@
                     "radar_infrared": "Radar + Infrarood",
                     "radar_only": "Alleen radar",
                     "infrared_only": "Alleen infrarood"
+                }
+            },
+            "ac_mode": {
+                "name": "Aircomodus",
+                "state": {
+                    "unconfigured": "Niet-geconfigureerde modus",
+                    "air_conditioner_with_socket": "Airco aangesloten op stopcontact",
+                    "air_conditioner_without_socket": "Airco niet aangesloten op stopcontact",
+                    "infrared_water_heater": "Infraroodboiler-modus",
+                    "16a_socket": "16 A stopcontactmodus"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/ru.json
+++ b/custom_components/ha_aqara_devices/translations/ru.json
@@ -71,6 +71,9 @@
             "doorbell_ring": {
                 "name": "Звонок в дверь"
             },
+            "ac_on_off_status": {
+                "name": "Статус включения/выключения кондиционера"
+            },
             "detection_area": {
                 "name": "Зона обнаружения {index}"
             }
@@ -448,6 +451,16 @@
                     "radar_infrared": "Радар + Инфракрасный",
                     "radar_only": "Только радар",
                     "infrared_only": "Только инфракрасный"
+                }
+            },
+            "ac_mode": {
+                "name": "Режим кондиционера",
+                "state": {
+                    "unconfigured": "Режим не настроен",
+                    "air_conditioner_with_socket": "Кондиционер подключён к розетке",
+                    "air_conditioner_without_socket": "Кондиционер не подключён к розетке",
+                    "infrared_water_heater": "Режим инфракрасного водонагревателя",
+                    "16a_socket": "Режим розетки 16 А"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/zh-Hans.json
+++ b/custom_components/ha_aqara_devices/translations/zh-Hans.json
@@ -98,6 +98,9 @@
             "doorbell_ring": {
                 "name": "门铃响铃"
             },
+            "ac_on_off_status": {
+                "name": "空调开关状态"
+            },
             "detection_area": {
                 "name": "检测区域 {index}"
             }
@@ -475,6 +478,16 @@
                     "radar_infrared": "雷达 + 红外",
                     "radar_only": "仅雷达",
                     "infrared_only": "仅红外"
+                }
+            },
+            "ac_mode": {
+                "name": "空调模式",
+                "state": {
+                    "unconfigured": "未配置模式",
+                    "air_conditioner_with_socket": "空调已插入插座模式",
+                    "air_conditioner_without_socket": "空调未插入插座模式",
+                    "infrared_water_heater": "红外热水器模式",
+                    "16a_socket": "16A 插座模式"
                 }
             }
         },

--- a/custom_components/ha_aqara_devices/translations/zh-Hant.json
+++ b/custom_components/ha_aqara_devices/translations/zh-Hant.json
@@ -98,6 +98,9 @@
             "doorbell_ring": {
                 "name": "門鈴響鈴"
             },
+            "ac_on_off_status": {
+                "name": "空調開關狀態"
+            },
             "detection_area": {
                 "name": "偵測區域 {index}"
             }
@@ -475,6 +478,16 @@
                     "radar_infrared": "雷達 + 紅外線",
                     "radar_only": "僅雷達",
                     "infrared_only": "僅紅外線"
+                }
+            },
+            "ac_mode": {
+                "name": "空調模式",
+                "state": {
+                    "unconfigured": "未設定模式",
+                    "air_conditioner_with_socket": "空調已插入插座模式",
+                    "air_conditioner_without_socket": "空調未插入插座模式",
+                    "infrared_water_heater": "紅外線熱水器模式",
+                    "16a_socket": "16A 插座模式"
                 }
             }
         },


### PR DESCRIPTION
## Summary
- Add Aqara Hub M200 discovery for model `lumi.gateway.agl011`.
- Wire M200 coordinators, resource subscriptions, and SSE push updates.
- Expose M200 binary sensor, number, and select entities and document them in the README.

## Verification
- Python syntax check passed for `custom_components/ha_aqara_devices`.
- `git diff --check` passed.
- Home Assistant restart was not run because the expected `ha-dev` container is not present in this Docker environment.