### PR TITLE
Add FP300 motion and work mode entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ After the first step, Aqara sends a verification code to your email address or p
 
 | Platform | Entities |
 | --- | --- |
-| `binary_sensor` | Presence |
-| `sensor` | Temperature, Humidity, Illuminance, Battery |
+| `binary_sensor` | Presence, Motion |
+| `sensor` | Activity Status, Temperature, Humidity, Illuminance, Battery |
+| `select` | Work Mode |
 
 Each discovered G3, M3, FP2, or FP300 device in your Aqara account gets its own entities and device metadata inside Home Assistant.
 

--- a/custom_components/ha_aqara_devices/bridge_specs.py
+++ b/custom_components/ha_aqara_devices/bridge_specs.py
@@ -14,7 +14,7 @@ from .const import FP2_MODEL, FP300_MODEL
 from .fp2 import FP2_BINARY_SENSORS_DEF, FP2_SENSOR_SPECS
 from .fp300 import FP300_BINARY_SENSORS_DEF, FP300_SENSOR_SPECS
 from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, M100_NUMBERS_DEF, M3_NUMBERS_DEF
-from .selects import G410_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
+from .selects import FP300_SELECTS_DEF, G410_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
 from .sensors import G410_SENSORS_DEF, M100_SENSORS_DEF, M3_SENSORS_DEF
 from .switches import ALL_SWITCHES_DEF, G2H_PRO_SWITCHES_DEF, G410_SWITCHES_DEF, M100_SWITCHES_DEF
 
@@ -160,6 +160,7 @@ FP2_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(
 FP300_STATE_SPECS = [
     *FP300_BINARY_SENSORS_DEF,
     *FP300_SENSOR_SPECS,
+    *FP300_SELECTS_DEF,
 ]
 FP300_GROUP_SPECS = {
     group: [spec for spec in FP300_STATE_SPECS if spec.get("poll_group") == group and spec.get("api")]
@@ -232,12 +233,15 @@ def _collect_presence_resources(
     did: str,
     binary_specs: Iterable[dict[str, Any]],
     sensor_specs: Iterable[dict[str, Any]],
+    select_specs: Iterable[dict[str, Any]] = (),
 ) -> list[str]:
     resource_ids: dict[str, None] = {}
     for spec in binary_specs:
         _append_resource_if_enabled(resource_ids, enabled_unique_ids, f"{did}_fp2_{spec['key']}", spec)
     for spec in sensor_specs:
         _append_resource_if_enabled(resource_ids, enabled_unique_ids, f"{did}_fp2_sensor_{spec['key']}", spec)
+    for spec in select_specs:
+        _append_resource_if_enabled(resource_ids, enabled_unique_ids, f"{did}_{spec['inApp']}", spec)
     return list(resource_ids)
 
 
@@ -298,6 +302,7 @@ def build_active_subscriptions(
                 did,
                 FP300_BINARY_SENSORS_DEF,
                 FP300_SENSOR_SPECS,
+                FP300_SELECTS_DEF,
             )
         else:
             continue

--- a/custom_components/ha_aqara_devices/fp300.py
+++ b/custom_components/ha_aqara_devices/fp300.py
@@ -14,10 +14,36 @@ FP300_BINARY_SENSORS_DEF = [
         "icon": "mdi:motion-sensor",
         "on_values": {"1"},
     },
+    {
+        "name": "Motion",
+        "key": "people_active_status",
+        "api": "13.1.85",
+        "poll_group": "fast",
+        "device_class": BinarySensorDeviceClass.MOTION,
+        "icon": "mdi:motion-sensor",
+        "on_values": {"3"},
+        "value_type": "int",
+    },
 ]
 
 
+FP300_ACTIVITY_STATUS_MAP = {
+    "2": "unoccupied",
+    "3": "moving",
+    "4": "stationary",
+}
+
+
 FP300_SENSOR_SPECS = [
+    {
+        "name": "Activity Status",
+        "key": "people_active_status",
+        "api": "13.1.85",
+        "poll_group": "fast",
+        "icon": "mdi:motion-sensor",
+        "value_type": "int",
+        "value_map": FP300_ACTIVITY_STATUS_MAP,
+    },
     {
         "name": "Temperature",
         "key": "environment_temperature",

--- a/custom_components/ha_aqara_devices/select.py
+++ b/custom_components/ha_aqara_devices/select.py
@@ -11,9 +11,21 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .api import AqaraApi
-from .const import DOMAIN, G410_DEVICE_LABEL, M100_DEVICE_LABEL, M3_DEVICE_LABEL
+from .const import (
+    DOMAIN,
+    FP300_DEVICE_LABEL,
+    FP300_MODEL,
+    G410_DEVICE_LABEL,
+    M100_DEVICE_LABEL,
+    M3_DEVICE_LABEL,
+)
 from .device_info import build_device_info
-from .selects import G410_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
+from .selects import (
+    FP300_SELECTS_DEF,
+    G410_SELECTS_DEF,
+    M100_SELECTS_DEF,
+    M3_SELECTS_DEF,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,9 +36,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     g410_doorbells: list[dict] = data.get("g410_doorbells", [])
     hubs_m3: list[dict] = data.get("hubs_m3", [])
     hubs_m100: list[dict] = data.get("hubs_m100", [])
+    presence_devices: list[dict] = data.get("presence_devices", [])
     g410_coordinators: dict[str, DataUpdateCoordinator] = data.get("g410_coordinators", {})
     m3_coordinators: dict[str, DataUpdateCoordinator] = data.get("m3_coordinators", {})
     m100_coordinators: dict[str, DataUpdateCoordinator] = data.get("m100_coordinators", {})
+    presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]] = data.get("presence_coordinators", {})
 
     entities: list[SelectEntity] = []
 
@@ -87,6 +101,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 select_def,
                 model,
                 M100_DEVICE_LABEL,
+            )
+            entities.append(select)
+
+    for presence in presence_devices:
+        did = presence["did"]
+        name = presence["deviceName"]
+        model = presence.get("model") or ""
+        if model != FP300_MODEL:
+            continue
+
+        device_coordinators = presence_coordinators.get(did)
+        if not device_coordinators:
+            continue
+        coordinator = device_coordinators.get("slow")
+        if coordinator is None:
+            continue
+
+        for select_def in FP300_SELECTS_DEF:
+            select = AqaraSelect(
+                coordinator,
+                api,
+                did,
+                name,
+                select_def,
+                model,
+                FP300_DEVICE_LABEL,
             )
             entities.append(select)
 

--- a/custom_components/ha_aqara_devices/selects.py
+++ b/custom_components/ha_aqara_devices/selects.py
@@ -146,3 +146,22 @@ G410_SELECTS_DEF = [
     G410_IMAGE_FLIP,
     G410_CAMERA_MODE,
 ]
+
+FP300_WORK_MODE = {
+    "name": "Work Mode",
+    "icon": "mdi:radar",
+    "inApp": "work_mode",
+    "api": "14.59.85",
+    "poll_group": "slow",
+    "options": [
+        (0, "Radar + Infrared"),
+        (1, "Radar only"),
+        (2, "Infrared only"),
+    ],
+    "value_type": "int",
+    "default": None,
+}
+
+FP300_SELECTS_DEF = [
+    FP300_WORK_MODE,
+]


### PR DESCRIPTION
## Summary
- Add a FP300 Motion binary sensor from `people_active_status`, treating only `3` as motion.
- Add a FP300 Activity Status sensor so `unoccupied`, `moving`, and `stationary` remain visible.
- Add a FP300 Work Mode select and include it in polling/push resource wiring.

## Testing
- `python3 -m compileall custom_components/ha_aqara_devices`
- Not run: Home Assistant runtime restart because the expected `ha-dev` container was not present.

Closes #56