### PR TITLE
feat: translate entity names and states across all platforms

### DIFF
--- a/custom_components/ha_aqara_devices/binary_sensor.py
+++ b/custom_components/ha_aqara_devices/binary_sensor.py
@@ -213,10 +213,13 @@ class AqaraBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._model = model
         self._device_label = device_label
 
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+        elif "name" in spec:
+            self._attr_name = spec["name"]
         self._attr_icon = spec["icon"]
         self._attr_unique_id = f"{did}_{spec['inApp']}"
-        self._attr_translation_key = spec.get("translation_key")
         self._value_type = spec.get("value_type")
         self._hold_seconds = spec.get("hold_seconds", 5)
         self._clear_listener: Callable[[], None] | None = None
@@ -371,7 +374,14 @@ class AqaraFP2BinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._key = spec["key"]
         self._fallback_key = spec.get("fallback_key")
         self._on_values = {str(v) for v in spec.get("on_values", set())}
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+            placeholders = spec.get("translation_placeholders")
+            if placeholders:
+                self._attr_translation_placeholders = placeholders
+        elif "name" in spec:
+            self._attr_name = spec["name"]
         self._attr_icon = spec.get("icon")
         self._attr_unique_id = f"{did}_fp2_{self._key}"
         self._attr_entity_registry_enabled_default = spec.get("enabled_default", True)

--- a/custom_components/ha_aqara_devices/binary_sensors.py
+++ b/custom_components/ha_aqara_devices/binary_sensors.py
@@ -57,7 +57,6 @@ ALL_BINARY_SENSORS_DEF = [
 ]
 
 M3_ALARM_STATUS = {
-    "name": "Alarm Status",
     "icon": "mdi:alarm-bell",
     "inApp": "alarm_status",
     "api": "14.1.111",
@@ -66,7 +65,6 @@ M3_ALARM_STATUS = {
 }
 
 M3_DEVICE_ONLINE_STATUS = {
-    "name": "Device Online",
     "icon": "mdi:lan-connect",
     "inApp": "device_online_status",
     "api": "8.0.2045",
@@ -80,7 +78,6 @@ M3_BINARY_SENSORS_DEF = [
 ]
 
 M100_DEVICE_ONLINE_STATUS = {
-    "name": "Device Online",
     "icon": "mdi:lan-connect",
     "inApp": "device_online_status",
     "api": "8.0.2045",
@@ -94,6 +91,7 @@ M100_BINARY_SENSORS_DEF = [
 
 G410_DOORBELL_RING = {
     "name": "Doorbell Ring",
+    "translation_key": "doorbell_ring",
     "icon": "mdi:doorbell-video",
     "inApp": "bell_ring",
     "api": "13.12.85",
@@ -103,7 +101,6 @@ G410_DOORBELL_RING = {
 }
 
 G410_ALARM_STATUS = {
-    "name": "Alarm Status",
     "icon": "mdi:alarm-light",
     "inApp": "alarm_status",
     "api": "14.1.111",

--- a/custom_components/ha_aqara_devices/button.py
+++ b/custom_components/ha_aqara_devices/button.py
@@ -147,7 +147,7 @@ class AqaraG3PTZButton(ButtonEntity):
         self._api = api
         self._did = did
         self._direction = direction
-        self._attr_name = direction.capitalize()
+        self._attr_translation_key = f"ptz_{direction}"
         self._attr_icon = ICONS[direction]
         self._attr_unique_id = f"{did}_ptz_{direction}"
         self._device_name = device_name
@@ -169,7 +169,7 @@ class AqaraG3RingAlarmBell(ButtonEntity):
     def __init__(self, api: AqaraApi, did: str, device_name: str, model: str) -> None:
         self._api = api
         self._did = did
-        self._attr_name = "Ring Alarm Bell"
+        self._attr_translation_key = "ring_alarm_bell"
         self._attr_icon = ICONS["ring_alarm_bell"]
         self._attr_unique_id = f"{did}_ring_alarm_bell"
         self._device_name = device_name
@@ -220,7 +220,7 @@ class AqaraResourceButton(ButtonEntity):
         self._device_label = device_label
         self._resource_id = resource_id
         self._value = value
-        self._attr_name = name
+        self._attr_translation_key = key
         self._attr_icon = ICONS[key]
         self._attr_unique_id = f"{did}_{key}"
 

--- a/custom_components/ha_aqara_devices/fp2.py
+++ b/custom_components/ha_aqara_devices/fp2.py
@@ -14,9 +14,16 @@ from .const import (
 )
 
 
+def _enum_options(value_map: dict) -> list[str]:
+    """Build a de-duplicated, order-preserving option list from a value_map."""
+    return list(dict.fromkeys(value_map.values()))
+
+
 def _zone_presence_binary_sensor(index: int) -> dict:
     return {
         "name": f"Detection Area {index}",
+        "translation_key": "detection_area",
+        "translation_placeholders": {"index": str(index)},
         "key": f"detection_area{index}",
         "api": f"3.{index}.85",
         "poll_group": "fast",
@@ -34,7 +41,6 @@ FP2_ZONE_BINARY_SENSORS_DEF = [
 
 FP2_BINARY_SENSORS_DEF = [
     {
-        "name": "Presence",
         "key": "fp2_presence_state",
         "api": "3.51.85",
         "poll_group": "presence",
@@ -43,7 +49,6 @@ FP2_BINARY_SENSORS_DEF = [
         "on_values": {"1"},
     },
     {
-        "name": "Connectivity",
         "key": "device_offline_status",
         "api": "8.0.2045",
         "poll_group": "fast",
@@ -58,6 +63,8 @@ FP2_BINARY_SENSORS_DEF = [
 def _zone_statistics_sensor(index: int) -> dict:
     return {
         "name": f"Zone {index} People Count (10s)",
+        "translation_key": "zone_people_count_10s",
+        "translation_placeholders": {"index": str(index)},
         "key": f"zone{index}_statistics",
         "api": f"13.{120 + index}.85",
         "poll_group": "medium",
@@ -71,6 +78,8 @@ def _zone_statistics_sensor(index: int) -> dict:
 def _zone_minute_statistics_sensor(index: int) -> dict:
     return {
         "name": f"Zone {index} People Count (per minute)",
+        "translation_key": "zone_people_count_per_minute",
+        "translation_placeholders": {"index": str(index)},
         "key": f"zone{index}_people_counting_by_mins",
         "api": f"0.{120 + index}.85",
         "poll_group": "medium",
@@ -84,6 +93,7 @@ def _zone_minute_statistics_sensor(index: int) -> dict:
 FP2_COUNT_SENSORS_DEF = [
     {
         "name": "People Counting",
+        "translation_key": "people_counting",
         "key": "people_counting",
         "api": "0.60.85",
         "poll_group": "medium",
@@ -93,6 +103,7 @@ FP2_COUNT_SENSORS_DEF = [
     },
     {
         "name": "People Counting (per minute)",
+        "translation_key": "people_counting_per_minute",
         "key": "people_counting_by_mins",
         "api": "0.61.85",
         "poll_group": "medium",
@@ -102,6 +113,7 @@ FP2_COUNT_SENSORS_DEF = [
     },
     {
         "name": "Whole Area People Count (10s)",
+        "translation_key": "whole_area_people_count_10s",
         "key": "all_zone_statistics",
         "api": "13.120.85",
         "poll_group": "medium",
@@ -121,7 +133,6 @@ FP2_COUNT_SENSORS_DEF = [
 
 FP2_STATUS_SENSORS_DEF = [
     {
-        "name": "Illuminance",
         "key": "lux",
         "api": "0.4.85",
         "poll_group": "medium",
@@ -133,6 +144,7 @@ FP2_STATUS_SENSORS_DEF = [
     },
     {
         "name": "Heart Rate",
+        "translation_key": "heart_rate",
         "key": "heartrate_value",
         "api": "0.8.85",
         "poll_group": "medium",
@@ -142,6 +154,7 @@ FP2_STATUS_SENSORS_DEF = [
     },
     {
         "name": "Respiration Rate",
+        "translation_key": "respiration_rate",
         "key": "respiration_rate_value",
         "api": "0.9.85",
         "poll_group": "medium",
@@ -151,6 +164,7 @@ FP2_STATUS_SENSORS_DEF = [
     },
     {
         "name": "Body Movement",
+        "translation_key": "body_movement",
         "key": "body_movement_value",
         "api": "13.11.85",
         "poll_group": "fast",
@@ -159,6 +173,7 @@ FP2_STATUS_SENSORS_DEF = [
     },
     {
         "name": "Sleep State",
+        "translation_key": "sleep_state",
         "key": "sleep_state",
         "api": "13.106.85",
         "poll_group": "medium",
@@ -167,41 +182,54 @@ FP2_STATUS_SENSORS_DEF = [
     },
     {
         "name": "Operating Mode",
+        "translation_key": "operating_mode",
         "key": "set_device_mode4",
         "api": "14.49.85",
         "poll_group": "slow",
         "icon": "mdi:cog",
         "value_type": "str",
+        "device_class": SensorDeviceClass.ENUM,
         "value_map": FP2_MODE_LABELS,
+        "options": _enum_options(FP2_MODE_LABELS),
     },
     {
         "name": "View Zoom",
+        "translation_key": "view_zoom",
         "key": "view_zoom",
         "poll_group": "slow",
         "icon": "mdi:magnify-scan",
         "value_type": "str",
+        "device_class": SensorDeviceClass.ENUM,
         "value_map": FP2_VIEW_MODES,
+        "options": _enum_options(FP2_VIEW_MODES),
     },
     {
         "name": "Mounting Position",
+        "translation_key": "mounting_position",
         "key": "mounting_position",
         "api": "14.57.85",
         "poll_group": "slow",
         "icon": "mdi:wall",
         "value_type": "str",
+        "device_class": SensorDeviceClass.ENUM,
         "value_map": FP2_MOUNTING_POSITIONS,
+        "options": _enum_options(FP2_MOUNTING_POSITIONS),
     },
     {
         "name": "Installation Angle",
+        "translation_key": "installation_angle",
         "key": "installation_angle",
         "api": "13.35.85",
         "poll_group": "slow",
         "icon": "mdi:rotate-3d-variant",
         "value_type": "str",
+        "device_class": SensorDeviceClass.ENUM,
         "value_map": FP2_INSTALLATION_ANGLES,
+        "options": _enum_options(FP2_INSTALLATION_ANGLES),
     },
     {
         "name": "Attitude Status",
+        "translation_key": "attitude_status",
         "key": "attitude_status",
         "api": "13.70.85",
         "poll_group": "slow",
@@ -210,70 +238,31 @@ FP2_STATUS_SENSORS_DEF = [
     },
 ]
 
+
+def _fp2_setting_sensor(name: str, translation_key: str, key: str, api: str, icon: str) -> dict:
+    value_map = FP2_SETTING_VALUE_MAPS[key]
+    return {
+        "name": name,
+        "translation_key": translation_key,
+        "key": key,
+        "api": api,
+        "poll_group": "slow",
+        "icon": icon,
+        "value_type": "str",
+        "device_class": SensorDeviceClass.ENUM,
+        "value_map": value_map,
+        "options": _enum_options(value_map),
+    }
+
+
 FP2_SETTINGS_SENSORS_DEF = [
-    {
-        "name": "Presence Sensitivity",
-        "key": "presence_detection_sens",
-        "api": "14.1.85",
-        "poll_group": "slow",
-        "icon": "mdi:account-eye",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["presence_detection_sens"],
-    },
-    {
-        "name": "Proximity Distance",
-        "key": "proximity_sensing_dist",
-        "api": "14.47.85",
-        "poll_group": "slow",
-        "icon": "mdi:signal-distance-variant",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["proximity_sensing_dist"],
-    },
-    {
-        "name": "Fall Detection Sensitivity",
-        "key": "fall_detection_sens",
-        "api": "14.30.85",
-        "poll_group": "slow",
-        "icon": "mdi:human-female-fall",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["fall_detection_sens"],
-    },
-    {
-        "name": "Reverse Coordinate Direction",
-        "key": "reverse_coordinate_dir",
-        "api": "14.51.85",
-        "poll_group": "slow",
-        "icon": "mdi:axes-arrow",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["reverse_coordinate_dir"],
-    },
-    {
-        "name": "Detection Direction",
-        "key": "detection_dir",
-        "api": "14.55.85",
-        "poll_group": "slow",
-        "icon": "mdi:axis-z-arrow",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["detection_dir"],
-    },
-    {
-        "name": "AI Person Detection",
-        "key": "ai_person_det",
-        "api": "4.72.85",
-        "poll_group": "slow",
-        "icon": "mdi:account-search",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["ai_person_det"],
-    },
-    {
-        "name": "Anti-light Pollution Mode",
-        "key": "anti_light_poll",
-        "api": "4.23.85",
-        "poll_group": "slow",
-        "icon": "mdi:white-balance-sunny",
-        "value_type": "str",
-        "value_map": FP2_SETTING_VALUE_MAPS["anti_light_poll"],
-    },
+    _fp2_setting_sensor("Presence Sensitivity", "presence_sensitivity", "presence_detection_sens", "14.1.85", "mdi:account-eye"),
+    _fp2_setting_sensor("Proximity Distance", "proximity_distance", "proximity_sensing_dist", "14.47.85", "mdi:signal-distance-variant"),
+    _fp2_setting_sensor("Fall Detection Sensitivity", "fall_detection_sensitivity", "fall_detection_sens", "14.30.85", "mdi:human-female-fall"),
+    _fp2_setting_sensor("Reverse Coordinate Direction", "reverse_coordinate_direction", "reverse_coordinate_dir", "14.51.85", "mdi:axes-arrow"),
+    _fp2_setting_sensor("Detection Direction", "detection_direction", "detection_dir", "14.55.85", "mdi:axis-z-arrow"),
+    _fp2_setting_sensor("AI Person Detection", "ai_person_detection", "ai_person_det", "4.72.85", "mdi:account-search"),
+    _fp2_setting_sensor("Anti-light Pollution Mode", "anti_light_pollution_mode", "anti_light_poll", "4.23.85", "mdi:white-balance-sunny"),
 ]
 
 FP2_SENSOR_SPECS = [

--- a/custom_components/ha_aqara_devices/fp300.py
+++ b/custom_components/ha_aqara_devices/fp300.py
@@ -6,7 +6,6 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 FP300_BINARY_SENSORS_DEF = [
     {
-        "name": "Presence",
         "key": "report_status01",
         "api": "3.51.85",
         "poll_group": "fast",
@@ -15,7 +14,6 @@ FP300_BINARY_SENSORS_DEF = [
         "on_values": {"1"},
     },
     {
-        "name": "Motion",
         "key": "people_active_status",
         "api": "13.1.85",
         "poll_group": "fast",
@@ -37,15 +35,17 @@ FP300_ACTIVITY_STATUS_MAP = {
 FP300_SENSOR_SPECS = [
     {
         "name": "Activity Status",
+        "translation_key": "activity_status",
         "key": "people_active_status",
         "api": "13.1.85",
         "poll_group": "fast",
         "icon": "mdi:motion-sensor",
         "value_type": "int",
+        "device_class": SensorDeviceClass.ENUM,
         "value_map": FP300_ACTIVITY_STATUS_MAP,
+        "options": list(dict.fromkeys(FP300_ACTIVITY_STATUS_MAP.values())),
     },
     {
-        "name": "Temperature",
         "key": "environment_temperature",
         "api": "0.1.85",
         "poll_group": "medium",
@@ -57,7 +57,6 @@ FP300_SENSOR_SPECS = [
         "scale": 0.01,
     },
     {
-        "name": "Humidity",
         "key": "environment_humidity",
         "api": "0.2.85",
         "poll_group": "medium",
@@ -69,7 +68,6 @@ FP300_SENSOR_SPECS = [
         "scale": 0.01,
     },
     {
-        "name": "Illuminance",
         "key": "lux",
         "api": "0.3.85",
         "poll_group": "medium",
@@ -80,7 +78,6 @@ FP300_SENSOR_SPECS = [
         "value_type": "float",
     },
     {
-        "name": "Battery",
         "key": "battery_percentage",
         "api": "8.0.2001",
         "poll_group": "slow",

--- a/custom_components/ha_aqara_devices/manifest.json
+++ b/custom_components/ha_aqara_devices/manifest.json
@@ -6,8 +6,6 @@
   "documentation": "https://github.com/ton-repo/aqara_g3_integration",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/Darkdragon14/ha-aqara-devices/issues",
-  "requirements": [
-    "pycryptodome>=3.20.0"
-  ],
-  "version": "1.2.0"
+  "requirements": ["pycryptodome>=3.20.0"],
+  "version": "1.2.2"
 }

--- a/custom_components/ha_aqara_devices/number.py
+++ b/custom_components/ha_aqara_devices/number.py
@@ -133,11 +133,14 @@ class AqaraNumber(CoordinatorEntity, NumberEntity):
 
         self._attr_unique_id = f"{did}_{spec['inApp']}"
         self._native_value: float | None = None
-        self._attr_name = "System Volume"
         self._attr_native_min_value = float(spec['min'])
         self._attr_native_max_value = float(spec['max'])
         self._attr_native_step = float(spec["step"])
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+        else:
+            self._attr_name = spec["name"]
         self._attr_icon = spec["icon"]
 
     

--- a/custom_components/ha_aqara_devices/numbers.py
+++ b/custom_components/ha_aqara_devices/numbers.py
@@ -1,5 +1,6 @@
 VOLUME = {
     "name": "Volume",
+    "translation_key": "volume",
     "icon": "mdi:volume-high",
     "inApp": "volume",
     "api": "14.11.85",
@@ -15,6 +16,7 @@ ALL_NUMBERS_DEF = [
 
 M3_SYSTEM_VOLUME = {
     "name": "System Volume",
+    "translation_key": "system_volume",
     "icon": "mdi:volume-high",
     "inApp": "system_volume",
     "api": "14.11.85",
@@ -26,6 +28,7 @@ M3_SYSTEM_VOLUME = {
 
 M3_ALARM_BELL_VOLUME = {
     "name": "Alarm Volume",
+    "translation_key": "alarm_volume",
     "icon": "mdi:bell-ring",
     "inApp": "alarm_bell_volume",
     "api": "14.1.1000",
@@ -37,6 +40,7 @@ M3_ALARM_BELL_VOLUME = {
 
 M3_DOORBELL_BELL_VOLUME = {
     "name": "Doorbell Volume",
+    "translation_key": "doorbell_volume",
     "icon": "mdi:doorbell",
     "inApp": "doorbell_bell_volume",
     "api": "14.2.1000",
@@ -48,6 +52,7 @@ M3_DOORBELL_BELL_VOLUME = {
 
 M3_ALARM_TIME_LENGTH = {
     "name": "Alarm Duration",
+    "translation_key": "alarm_duration",
     "icon": "mdi:timer",
     "inApp": "alarm_time_length",
     "api": "14.1.113",
@@ -59,6 +64,7 @@ M3_ALARM_TIME_LENGTH = {
 
 M3_DOORBELL_TIME_LENGTH = {
     "name": "Doorbell Duration",
+    "translation_key": "doorbell_duration",
     "icon": "mdi:timer",
     "inApp": "doorbell_time_length",
     "api": "14.2.113",
@@ -78,6 +84,7 @@ M3_NUMBERS_DEF = [
 
 M100_MUSIC_VOLUME = {
     "name": "Music Volume",
+    "translation_key": "music_volume",
     "icon": "mdi:music-note",
     "inApp": "music_volume",
     "api": "14.3.1000",
@@ -89,6 +96,7 @@ M100_MUSIC_VOLUME = {
 
 M100_SYSTEM_VOLUME = {
     "name": "System Volume",
+    "translation_key": "system_volume",
     "icon": "mdi:volume-high",
     "inApp": "system_volume",
     "api": "14.11.85",
@@ -100,6 +108,7 @@ M100_SYSTEM_VOLUME = {
 
 M100_CLOCK_VOLUME = {
     "name": "Alarm Clock Volume",
+    "translation_key": "alarm_clock_volume",
     "icon": "mdi:alarm",
     "inApp": "clock_volume",
     "api": "14.5.1000",
@@ -111,6 +120,7 @@ M100_CLOCK_VOLUME = {
 
 M100_ALARM_BELL_VOLUME = {
     "name": "Alarm Volume",
+    "translation_key": "alarm_volume",
     "icon": "mdi:bell-ring",
     "inApp": "alarm_bell_volume",
     "api": "14.1.1000",
@@ -122,6 +132,7 @@ M100_ALARM_BELL_VOLUME = {
 
 M100_NIGHT_LIGHT_BRIGHTNESS = {
     "name": "Night Light Brightness",
+    "translation_key": "night_light_brightness",
     "icon": "mdi:brightness-6",
     "inApp": "brightness_level",
     "api": "14.7.1006",
@@ -133,6 +144,7 @@ M100_NIGHT_LIGHT_BRIGHTNESS = {
 
 M100_ARMING_DELAY_TIME = {
     "name": "Arming Delay Time",
+    "translation_key": "arming_delay_time",
     "icon": "mdi:timer-sand",
     "inApp": "arming_delay_time",
     "api": "14.6.113",
@@ -153,6 +165,7 @@ M100_NUMBERS_DEF = [
 
 G2H_PRO_MUSIC_VOLUME = {
     "name": "Music Volume",
+    "translation_key": "music_volume",
     "icon": "mdi:music-note",
     "inApp": "music_volume",
     "api": "14.3.1000",
@@ -164,6 +177,7 @@ G2H_PRO_MUSIC_VOLUME = {
 
 G2H_PRO_CAMERA_VOLUME = {
     "name": "Camera Volume",
+    "translation_key": "camera_volume",
     "icon": "mdi:volume-high",
     "inApp": "camera_volume",
     "api": "14.65.85",
@@ -175,6 +189,7 @@ G2H_PRO_CAMERA_VOLUME = {
 
 G2H_PRO_ALARM_BELL_VOLUME = {
     "name": "Alarm Volume",
+    "translation_key": "alarm_volume",
     "icon": "mdi:bell-ring",
     "inApp": "alarm_bell_volume",
     "api": "14.1.1000",
@@ -192,6 +207,7 @@ G2H_PRO_NUMBERS_DEF = [
 
 G410_SYSTEM_VOLUME = {
     "name": "System Volume",
+    "translation_key": "system_volume",
     "icon": "mdi:volume-high",
     "inApp": "system_volume",
     "api": "14.11.85",
@@ -203,6 +219,7 @@ G410_SYSTEM_VOLUME = {
 
 G410_FACE_INTERVAL = {
     "name": "Face Recognition Interval",
+    "translation_key": "face_recognition_interval",
     "icon": "mdi:face-recognition",
     "inApp": "face_interval",
     "api": "14.110.85",
@@ -214,6 +231,7 @@ G410_FACE_INTERVAL = {
 
 G410_ALARM_BELL_VOLUME = {
     "name": "Alarm Volume",
+    "translation_key": "alarm_volume",
     "icon": "mdi:bell-ring",
     "inApp": "alarm_bell_volume",
     "api": "14.1.1000",
@@ -225,6 +243,7 @@ G410_ALARM_BELL_VOLUME = {
 
 G410_CAMERA_VOLUME = {
     "name": "Camera Volume",
+    "translation_key": "camera_volume",
     "icon": "mdi:volume-high",
     "inApp": "camera_volume",
     "api": "14.65.85",

--- a/custom_components/ha_aqara_devices/select.py
+++ b/custom_components/ha_aqara_devices/select.py
@@ -179,13 +179,17 @@ class AqaraSelect(CoordinatorEntity, SelectEntity):
         self._device_label = device_label
 
         self._attr_unique_id = f"{did}_{spec['inApp']}"
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+        else:
+            self._attr_name = spec["name"]
         self._attr_icon = spec.get("icon")
 
         option_pairs = spec.get("options", [])
-        self._option_by_value = {value: label for value, label in option_pairs}
-        self._value_by_option = {label: value for value, label in option_pairs}
-        self._attr_options = [label for _, label in option_pairs]
+        self._option_by_value = {value: slug for value, slug in option_pairs}
+        self._value_by_option = {slug: value for value, slug in option_pairs}
+        self._attr_options = [slug for _, slug in option_pairs]
 
     @property
     def device_info(self):

--- a/custom_components/ha_aqara_devices/selects.py
+++ b/custom_components/ha_aqara_devices/selects.py
@@ -1,37 +1,38 @@
 ALARM_BELL_INDEX_OPTIONS = [
-    (10000, "Default"),
-    (0, "Police car sound 1"),
-    (1, "Police car sound 2"),
-    (2, "Safety accident sound"),
-    (3, "Missile countdown"),
-    (4, "Ghost scream"),
-    (5, "Sniper rifle"),
-    (6, "Battle sound"),
-    (7, "Air raid alarm"),
-    (8, "Dog barking"),
+    (10000, "default"),
+    (0, "police_car_1"),
+    (1, "police_car_2"),
+    (2, "safety_accident"),
+    (3, "missile_countdown"),
+    (4, "ghost_scream"),
+    (5, "sniper_rifle"),
+    (6, "battle"),
+    (7, "air_raid_alarm"),
+    (8, "dog_barking"),
 ]
 
 DOORBELL_BELL_INDEX_OPTIONS = [
-    (10000, "Default"),
-    (0, "Index 0"),
-    (1, "Index 1"),
-    (2, "Index 2"),
-    (3, "Index 3"),
-    (4, "Index 4"),
-    (5, "Index 5"),
-    (6, "Index 6"),
-    (7, "Index 7"),
-    (8, "Index 8"),
+    (10000, "default"),
+    (0, "index_0"),
+    (1, "index_1"),
+    (2, "index_2"),
+    (3, "index_3"),
+    (4, "index_4"),
+    (5, "index_5"),
+    (6, "index_6"),
+    (7, "index_7"),
+    (8, "index_8"),
 ]
 
 M3_GATEWAY_LANGUAGE = {
     "name": "Gateway Language",
+    "translation_key": "gateway_language",
     "icon": "mdi:translate",
     "inApp": "gateway_language",
     "api": "14.10.85",
     "options": [
-        (0, "Chinese"),
-        (1, "English"),
+        (0, "chinese"),
+        (1, "english"),
     ],
     "value_type": "int",
     "default": None,
@@ -39,6 +40,7 @@ M3_GATEWAY_LANGUAGE = {
 
 M3_ALARM_BELL_INDEX = {
     "name": "Alarm Ringtone",
+    "translation_key": "alarm_ringtone",
     "icon": "mdi:bell",
     "inApp": "alarm_bell_index",
     "api": "14.1.85",
@@ -49,6 +51,7 @@ M3_ALARM_BELL_INDEX = {
 
 M3_DOORBELL_BELL_INDEX = {
     "name": "Doorbell Ringtone",
+    "translation_key": "doorbell_ringtone",
     "icon": "mdi:doorbell",
     "inApp": "doorbell_bell_index",
     "api": "14.2.85",
@@ -65,12 +68,13 @@ M3_SELECTS_DEF = [
 
 M100_GATEWAY_LANGUAGE = {
     "name": "Gateway Language",
+    "translation_key": "gateway_language",
     "icon": "mdi:translate",
     "inApp": "gateway_language",
     "api": "14.10.85",
     "options": [
-        (1, "Chinese"),
-        (2, "English"),
+        (1, "chinese"),
+        (2, "english"),
     ],
     "value_type": "int",
     "default": None,
@@ -78,6 +82,7 @@ M100_GATEWAY_LANGUAGE = {
 
 M100_ALARM_BELL_INDEX = {
     "name": "Alarm Ringtone",
+    "translation_key": "alarm_ringtone",
     "icon": "mdi:bell",
     "inApp": "alarm_bell_index",
     "api": "14.1.85",
@@ -88,6 +93,7 @@ M100_ALARM_BELL_INDEX = {
 
 M100_DOORBELL_BELL_INDEX = {
     "name": "Doorbell Ringtone",
+    "translation_key": "doorbell_ringtone",
     "icon": "mdi:doorbell",
     "inApp": "doorbell_bell_index",
     "api": "14.2.85",
@@ -104,6 +110,7 @@ M100_SELECTS_DEF = [
 
 G410_ALARM_BELL_INDEX = {
     "name": "Alarm Ringtone",
+    "translation_key": "alarm_ringtone",
     "icon": "mdi:bell",
     "inApp": "alarm_bell_index",
     "api": "14.1.85",
@@ -114,14 +121,15 @@ G410_ALARM_BELL_INDEX = {
 
 G410_IMAGE_FLIP = {
     "name": "Screen Flip",
+    "translation_key": "screen_flip",
     "icon": "mdi:flip-horizontal",
     "inApp": "image_flip",
     "api": "14.68.85",
     "options": [
-        (0, "Normal"),
-        (1, "Flip Horizontally"),
-        (2, "Flip Vertically"),
-        (3, "Flip Horizontally and Vertically"),
+        (0, "normal"),
+        (1, "flip_horizontally"),
+        (2, "flip_vertically"),
+        (3, "flip_horizontally_and_vertically"),
     ],
     "value_type": "int",
     "default": None,
@@ -129,13 +137,14 @@ G410_IMAGE_FLIP = {
 
 G410_CAMERA_MODE = {
     "name": "Camera Mode",
+    "translation_key": "camera_mode",
     "icon": "mdi:video",
     "inApp": "ctrl_camera",
     "api": "4.8.85",
     "options": [
-        (0, "Off"),
-        (1, "On"),
-        (255, "Always On"),
+        (0, "off"),
+        (1, "on"),
+        (255, "always_on"),
     ],
     "value_type": "int",
     "default": None,
@@ -153,14 +162,15 @@ G4_SELECTS_DEF = [
 
 FP300_WORK_MODE = {
     "name": "Work Mode",
+    "translation_key": "work_mode",
     "icon": "mdi:radar",
     "inApp": "work_mode",
     "api": "14.59.85",
     "poll_group": "slow",
     "options": [
-        (0, "Radar + Infrared"),
-        (1, "Radar only"),
-        (2, "Infrared only"),
+        (0, "radar_infrared"),
+        (1, "radar_only"),
+        (2, "infrared_only"),
     ],
     "value_type": "int",
     "default": None,

--- a/custom_components/ha_aqara_devices/sensor.py
+++ b/custom_components/ha_aqara_devices/sensor.py
@@ -209,9 +209,16 @@ class AqaraSensor(CoordinatorEntity, SensorEntity):
         self._device_label = device_label
 
         self._attr_unique_id = f"{did}_{spec['inApp']}"
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+        elif "name" in spec:
+            self._attr_name = spec["name"]
         self._attr_icon = spec.get("icon")
         self._attr_native_unit_of_measurement = spec.get("unit")
+        options = spec.get("options")
+        if options is not None:
+            self._attr_options = options
 
         device_class = spec.get("device_class")
         if isinstance(device_class, SensorDeviceClass):
@@ -243,7 +250,10 @@ class AqaraSensor(CoordinatorEntity, SensorEntity):
         raw = data.get(self._spec["inApp"])
         if raw is None:
             return
-        self._attr_native_value = self._value_map.get(str(raw), raw)
+        value = self._value_map.get(str(raw), raw)
+        if self._attr_options is not None and value not in self._attr_options:
+            value = None
+        self._attr_native_value = value
         self.async_write_ha_state()
 
 
@@ -267,7 +277,14 @@ class AqaraFP2Sensor(CoordinatorEntity, SensorEntity):
         self._device_label = device_label
         self._key = spec["key"]
 
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+            placeholders = spec.get("translation_placeholders")
+            if placeholders:
+                self._attr_translation_placeholders = placeholders
+        elif "name" in spec:
+            self._attr_name = spec["name"]
         self._attr_icon = spec.get("icon")
         self._attr_unique_id = f"{did}_fp2_sensor_{self._key}"
         self._value_type = spec.get("value_type")
@@ -276,6 +293,9 @@ class AqaraFP2Sensor(CoordinatorEntity, SensorEntity):
         self._attr_native_unit_of_measurement = spec.get("unit")
         self._attr_device_class = spec.get("device_class")
         self._attr_state_class = spec.get("state_class")
+        options = spec.get("options")
+        if options is not None:
+            self._attr_options = options
         self._attr_entity_registry_enabled_default = spec.get("enabled_default", True)
 
     @property
@@ -289,7 +309,10 @@ class AqaraFP2Sensor(CoordinatorEntity, SensorEntity):
         if raw is None:
             return None
         if self._value_map:
-            return self._value_map.get(str(raw), raw)
+            value = self._value_map.get(str(raw), raw)
+            if self._attr_options is not None and value not in self._attr_options:
+                return None
+            return value
 
         def _apply_scale(value: int | float):
             if self._scale is None:

--- a/custom_components/ha_aqara_devices/sensors.py
+++ b/custom_components/ha_aqara_devices/sensors.py
@@ -1,7 +1,6 @@
 from homeassistant.const import UnitOfTemperature, PERCENTAGE
 
 M3_TEMPERATURE = {
-    "name": "Temperature",
     "icon": "mdi:thermometer",
     "inApp": "temperature_value",
     "api": "0.1.85",
@@ -14,7 +13,6 @@ M3_TEMPERATURE = {
 }
 
 M3_HUMIDITY = {
-    "name": "Humidity",
     "icon": "mdi:water-percent",
     "inApp": "humidity_value",
     "api": "0.2.85",
@@ -32,6 +30,7 @@ M3_SENSORS_DEF = [
 
 M100_GATEWAY_TIME_ZONE = {
     "name": "Gateway Time Zone",
+    "translation_key": "gateway_time_zone",
     "icon": "mdi:map-clock",
     "inApp": "gw_time_zone",
     "api": "14.12.85",
@@ -41,6 +40,7 @@ M100_GATEWAY_TIME_ZONE = {
 
 M100_NIGHT_LIGHT_CONFIGURATION = {
     "name": "Night Light Configuration",
+    "translation_key": "night_light_configuration",
     "icon": "mdi:weather-night",
     "inApp": "en_nnlight",
     "api": "14.21.85",
@@ -54,7 +54,6 @@ M100_SENSORS_DEF = [
 ]
 
 G410_BATTERY_LEVEL = {
-    "name": "Battery Level",
     "icon": "mdi:battery",
     "inApp": "device_battery_power",
     "api": "8.0.2001",
@@ -67,6 +66,7 @@ G410_BATTERY_LEVEL = {
 
 G410_FACE_RECOGNITION_EVENT = {
     "name": "Face Recognition Event",
+    "translation_key": "face_recognition_event",
     "icon": "mdi:face-recognition",
     "inApp": "detect_face_event",
     "api": "13.95.85",
@@ -76,6 +76,7 @@ G410_FACE_RECOGNITION_EVENT = {
 
 G410_STRANGER_FACE_EVENT = {
     "name": "Stranger Face Event",
+    "translation_key": "stranger_face_event",
     "icon": "mdi:face-agent",
     "inApp": "detect_stranger_face_event",
     "api": "13.108.85",
@@ -96,66 +97,106 @@ G4_SENSORS_DEF = [
 
 A100_PRO_DOOR_EVENT = {
     "name": "Door Event",
+    "translation_key": "door_event",
     "icon": "mdi:door",
     "inApp": "door_event",
     "api": "13.17.85",
     "value_type": "uint8_t",
+    "device_class": "enum",
     "value_map": {
-        "0": "Door opened",
-        "1": "Door closed",
-        "2": "Timeout without closing",
-        "3": "Knock on the door",
-        "4": "Attempted break-in",
-        "5": "Door ajar",
+        "0": "door_opened",
+        "1": "door_closed",
+        "2": "timeout_without_closing",
+        "3": "knock_on_the_door",
+        "4": "attempted_break_in",
+        "5": "door_ajar",
     },
+    "options": [
+        "door_opened",
+        "door_closed",
+        "timeout_without_closing",
+        "knock_on_the_door",
+        "attempted_break_in",
+        "door_ajar",
+    ],
     "default": None,
 }
 
 A100_PRO_LOCK_STATE = {
     "name": "Door Lock Status",
+    "translation_key": "lock_state",
     "icon": "mdi:lock",
     "inApp": "lock_state",
     "api": "13.88.85",
     "value_type": "uint8_t",
+    "device_class": "enum",
     "value_map": {
-        "1": "Door can't be closed",
-        "2": "Door is open",
-        "3": "Door is closed but front handle is not lifted",
-        "4": "Door is locked",
-        "5": "Door is locked by night latch knob",
-        "6": "Door is unlocked",
-        "7": "Door is locked by front handle and night latch knob",
-        "8": "Door is almost closed",
+        "1": "door_cannot_be_closed",
+        "2": "door_is_open",
+        "3": "door_closed_handle_not_lifted",
+        "4": "door_is_locked",
+        "5": "door_is_locked_by_night_latch_knob",
+        "6": "door_is_unlocked",
+        "7": "door_is_locked_by_front_handle_and_night_latch_knob",
+        "8": "door_is_almost_closed",
     },
+    "options": [
+        "door_cannot_be_closed",
+        "door_is_open",
+        "door_closed_handle_not_lifted",
+        "door_is_locked",
+        "door_is_locked_by_night_latch_knob",
+        "door_is_unlocked",
+        "door_is_locked_by_front_handle_and_night_latch_knob",
+        "door_is_almost_closed",
+    ],
     "default": None,
 }
 
 A100_PRO_OPEN_DOOR_METHOD = {
     "name": "Open Door Method",
+    "translation_key": "open_door_method",
     "icon": "mdi:key-chain",
     "inApp": "open_door_method_id",
     "api": "13.18.85",
     "value_type": "uint32_t",
+    "device_class": "enum",
     "value_map": {
-        "0": "Fingerprint unlock",
-        "1": "Permanent password unlock",
-        "2": "NFC unlock",
-        "3": "Bluetooth unlock",
-        "4": "Temporary password unlock",
-        "5": "Mechanical key unlock",
-        "6": "Dual authentication unlock",
-        "7": "Duress fingerprint unlock",
-        "8": "HomeKit unlock",
-        "9": "Face unlock",
-        "10": "AIoT remote unlock",
-        "11": "Google password unlock",
-        "15": "Outdoor unlock",
+        "0": "fingerprint_unlock",
+        "1": "permanent_password_unlock",
+        "2": "nfc_unlock",
+        "3": "bluetooth_unlock",
+        "4": "temporary_password_unlock",
+        "5": "mechanical_key_unlock",
+        "6": "dual_authentication_unlock",
+        "7": "duress_fingerprint_unlock",
+        "8": "homekit_unlock",
+        "9": "face_unlock",
+        "10": "aiot_remote_unlock",
+        "11": "google_password_unlock",
+        "15": "outdoor_unlock",
     },
+    "options": [
+        "fingerprint_unlock",
+        "permanent_password_unlock",
+        "nfc_unlock",
+        "bluetooth_unlock",
+        "temporary_password_unlock",
+        "mechanical_key_unlock",
+        "dual_authentication_unlock",
+        "duress_fingerprint_unlock",
+        "homekit_unlock",
+        "face_unlock",
+        "aiot_remote_unlock",
+        "google_password_unlock",
+        "outdoor_unlock",
+    ],
     "default": None,
 }
 
 A100_PRO_USER_ID_FINGERPRINT = {
     "name": "Fingerprint User ID",
+    "translation_key": "user_id_fingerprint",
     "icon": "mdi:fingerprint",
     "inApp": "user_id_fingerprint",
     "api": "13.42.85",
@@ -165,6 +206,7 @@ A100_PRO_USER_ID_FINGERPRINT = {
 
 A100_PRO_USER_ID_PASSWORD = {
     "name": "Password User ID",
+    "translation_key": "user_id_password",
     "icon": "mdi:form-textbox-password",
     "inApp": "user_id_password",
     "api": "13.43.85",
@@ -174,6 +216,7 @@ A100_PRO_USER_ID_PASSWORD = {
 
 A100_PRO_USER_ID_NFC = {
     "name": "NFC User ID",
+    "translation_key": "user_id_nfc",
     "icon": "mdi:nfc",
     "inApp": "user_id_nfc",
     "api": "13.44.85",
@@ -183,6 +226,7 @@ A100_PRO_USER_ID_NFC = {
 
 A100_PRO_USER_ID_BLE_HOMEKIT = {
     "name": "HomeKit Bluetooth User ID",
+    "translation_key": "user_id_ble_homekit",
     "icon": "mdi:bluetooth",
     "inApp": "user_id_ble_homekit",
     "api": "13.45.85",
@@ -192,6 +236,7 @@ A100_PRO_USER_ID_BLE_HOMEKIT = {
 
 A100_PRO_USER_ID_TEMPORARY_PASSWORD = {
     "name": "Temporary Password User ID",
+    "translation_key": "user_id_temporary_password",
     "icon": "mdi:lock-clock",
     "inApp": "user_id_temporary_password",
     "api": "13.46.85",

--- a/custom_components/ha_aqara_devices/switch.py
+++ b/custom_components/ha_aqara_devices/switch.py
@@ -158,7 +158,11 @@ class AqaraResourceSwitch(CoordinatorEntity, SwitchEntity):
         self._model = model
         self._device_label = device_label
 
-        self._attr_name = spec["name"]
+        translation_key = spec.get("translation_key")
+        if translation_key:
+            self._attr_translation_key = translation_key
+        else:
+            self._attr_name = spec["name"]
         self._attr_icon = spec["icon"]
         self._attr_unique_id = f"{did}_{spec['inApp']}"
 

--- a/custom_components/ha_aqara_devices/switches.py
+++ b/custom_components/ha_aqara_devices/switches.py
@@ -2,6 +2,7 @@ from typing import Dict, Any
 
 VIDEO_SWITCH_DEF: Dict[str, Any] = {
     "name": "Video",
+    "translation_key": "video",
     "icon": "mdi:video",
     "inApp": "camera_active",
     "api": "14.74.85",
@@ -11,8 +12,9 @@ VIDEO_SWITCH_DEF: Dict[str, Any] = {
 
 DETECT_HUMAN_SWITCH_DEF: Dict[str, Any] = {
     "name": "Detect Human",
+    "translation_key": "detect_human",
     "icon": "mdi:motion-sensor",
-    "inApp": "human_detect_enable", 
+    "inApp": "human_detect_enable",
     "api": "14.77.85",
     "on_data":  {
         "14.77.85": "1",
@@ -26,8 +28,9 @@ DETECT_HUMAN_SWITCH_DEF: Dict[str, Any] = {
 
 DETECT_PET_SWITCH_DEF: Dict[str, Any] = {
     "name": "Detect Pet",
+    "translation_key": "detect_pet",
     "icon": "mdi:paw",
-    "inApp": "pets_track_enable", 
+    "inApp": "pets_track_enable",
     "api": "14.78.85",
     "on_data":  {
         "14.78.85": "1",
@@ -41,8 +44,9 @@ DETECT_PET_SWITCH_DEF: Dict[str, Any] = {
 
 DETECT_GESTURE_SWITCH_DEF: Dict[str, Any] = {
     "name": "Detect Gesture",
+    "translation_key": "detect_gesture",
     "icon": "mdi:hand-wave",
-    "inApp": "gesture_detect_enable", 
+    "inApp": "gesture_detect_enable",
     "api": "14.76.85",
     "on_data":  {
         "14.78.85": "0",
@@ -57,8 +61,9 @@ DETECT_GESTURE_SWITCH_DEF: Dict[str, Any] = {
 
 DETECT_FACE_SWITCH_DEF: Dict[str, Any] = {
     "name": "Detect Face",
+    "translation_key": "detect_face",
     "icon": "mdi:face-recognition",
-    "inApp": "face_detect_enable", 
+    "inApp": "face_detect_enable",
     "api": "14.75.85",
     "on_data":  {
         "14.78.85": "0",
@@ -81,6 +86,7 @@ ALL_SWITCHES_DEF = [
 
 M100_GATEWAY_DELETION_SETTING = {
     "name": "Sub-device Deletion Protection",
+    "translation_key": "sub_device_deletion_protection",
     "icon": "mdi:shield-remove",
     "inApp": "gateway_deletion_setting",
     "api": "8.0.2158",
@@ -94,9 +100,10 @@ M100_SWITCHES_DEF = [
 ]
 
 
-def _g2h_pro_switch(name: str, icon: str, in_app: str, api: str) -> Dict[str, Any]:
+def _g2h_pro_switch(name: str, translation_key: str, icon: str, in_app: str, api: str) -> Dict[str, Any]:
     return {
         "name": name,
+        "translation_key": translation_key,
         "icon": icon,
         "inApp": in_app,
         "api": api,
@@ -108,72 +115,84 @@ def _g2h_pro_switch(name: str, icon: str, in_app: str, api: str) -> Dict[str, An
 
 G2H_PRO_SOUND_DETECTION = _g2h_pro_switch(
     "Sound Detection",
+    "sound_detection",
     "mdi:volume-source",
     "soundtrigger_enable",
     "14.119.85",
 )
 G2H_PRO_TIMED_SLEEP = _g2h_pro_switch(
     "Timed Sleep",
+    "timed_sleep",
     "mdi:sleep",
     "time_sleep_enable",
     "14.125.85",
 )
 G2H_PRO_MOTION_PUSH = _g2h_pro_switch(
     "Motion Push",
+    "motion_push",
     "mdi:motion-sensor",
     "md_push_enable",
     "4.51.85",
 )
 G2H_PRO_MOTION_DETECTION = _g2h_pro_switch(
     "Motion Detection",
+    "motion_detection",
     "mdi:motion-sensor",
     "mdtrigger_enable",
     "14.70.85",
 )
 G2H_PRO_INDICATOR_LIGHT = _g2h_pro_switch(
     "Indicator Light",
+    "indicator_light",
     "mdi:led-on",
     "device_night_tip_light",
     "8.0.2032",
 )
 G2H_PRO_TIMELAPSE_PUSH = _g2h_pro_switch(
     "Timelapse Push",
+    "timelapse_push",
     "mdi:camera-timer",
     "camera_timelapse_push",
     "4.28.85",
 )
 G2H_PRO_SOUND_PUSH = _g2h_pro_switch(
     "Sound Push",
+    "sound_push",
     "mdi:volume-source",
     "cry_push_enable",
     "4.53.85",
 )
 G2H_PRO_DEVICE_OFFLINE_PUSH = _g2h_pro_switch(
     "Device Offline Push",
+    "device_offline_push",
     "mdi:lan-disconnect",
     "device_offline_push_enable",
     "4.89.85",
 )
 G2H_PRO_MOTION_RECORDING = _g2h_pro_switch(
     "Motion Recording",
+    "motion_recording",
     "mdi:record-rec",
     "md_record_enable",
     "4.50.85",
 )
 G2H_PRO_TIMELAPSE = _g2h_pro_switch(
     "Timelapse",
+    "timelapse",
     "mdi:camera-timer",
     "camera_timelapse_switch",
     "4.27.85",
 )
 G2H_PRO_SOUND_RECORDING = _g2h_pro_switch(
     "Sound Recording",
+    "sound_recording",
     "mdi:record-rec",
     "cry_record_enable",
     "4.52.85",
 )
 G2H_PRO_CAMERA = _g2h_pro_switch(
     "Camera",
+    "camera",
     "mdi:video",
     "set_video",
     "14.74.85",
@@ -195,9 +214,10 @@ G2H_PRO_SWITCHES_DEF = [
 ]
 
 
-def _g410_switch(name: str, icon: str, in_app: str, api: str) -> Dict[str, Any]:
+def _g410_switch(name: str, translation_key: str, icon: str, in_app: str, api: str) -> Dict[str, Any]:
     return {
         "name": name,
+        "translation_key": translation_key,
         "icon": icon,
         "inApp": in_app,
         "api": api,
@@ -209,54 +229,63 @@ def _g410_switch(name: str, icon: str, in_app: str, api: str) -> Dict[str, Any]:
 
 G410_HIGH_TEMP_ALARM = _g410_switch(
     "High Temperature Alarm",
+    "high_temp_alarm",
     "mdi:thermometer-alert",
     "high_temp_alarm",
     "4.67.85",
 )
 G410_FACE_PUSH = _g410_switch(
     "Face Recognition Push",
+    "face_recognition_push",
     "mdi:face-recognition",
     "face_push_enable",
     "4.55.85",
 )
 G410_SCHEDULED_SLEEP = _g410_switch(
     "Scheduled Sleep",
+    "scheduled_sleep",
     "mdi:sleep",
     "time_sleep_enable",
     "14.125.85",
 )
 G410_INDICATOR_LIGHT = _g410_switch(
     "Indicator Light",
+    "indicator_light",
     "mdi:led-on",
     "device_night_tip_light",
     "8.0.2032",
 )
 G410_ANTI_TAMPER_ALARM = _g410_switch(
     "Anti-Tamper Alarm",
+    "anti_tamper_alarm",
     "mdi:shield-alert",
     "damage_alarm",
     "4.66.85",
 )
 G410_FACE_RECORDING = _g410_switch(
     "Face Recording",
+    "face_recording",
     "mdi:record-rec",
     "face_record_enable",
     "4.54.85",
 )
 G410_DOORBELL_NOTIFICATION = _g410_switch(
     "Doorbell Notification",
+    "doorbell_notification",
     "mdi:bell-ring",
     "doorbell_push_enable",
     "4.154.85",
 )
 G410_LOW_TEMP_ALARM = _g410_switch(
     "Low Temperature Alarm",
+    "low_temp_alarm",
     "mdi:thermometer-alert",
     "low_temp_alarm",
     "4.68.85",
 )
 G410_DOORBELL_RECORDING = _g410_switch(
     "Doorbell Recording",
+    "doorbell_recording",
     "mdi:record-rec",
     "doorbell_record_enable",
     "4.138.85",

--- a/custom_components/ha_aqara_devices/translations/cz.json
+++ b/custom_components/ha_aqara_devices/translations/cz.json
@@ -59,18 +59,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Noční vidění" },
-            "gesture_v_sign": { "name": "Gesto znaku V" },
-            "gesture_four": { "name": "Gesto čtyři" },
-            "gesture_high_five": { "name": "Gesto High Five" },
-            "gesture_finger_gun": { "name": "Gesto pistole" },
-            "gesture_ok": { "name": "Gesto OK" },
-            "gesture_v_sign_both_hands": { "name": "Gesto znaku V obema rukama" },
-            "gesture_four_both_hands": { "name": "Gesto ctyri obema rukama" },
-            "gesture_high_five_both_hands": { "name": "Gesto High Five obema rukama" },
-            "gesture_finger_gun_both_hands": { "name": "Gesto pistole obema rukama" },
-            "gesture_ok_both_hands": { "name": "Gesto OK obema rukama" },
-            "motion_event": { "name": "Udalost pohybu" }
+            "night_vision": {
+                "name": "Noční vidění"
+            },
+            "motion_event": {
+                "name": "Událost pohybu"
+            },
+            "gesture_v_sign": {
+                "name": "Gesto znak V"
+            },
+            "gesture_four": {
+                "name": "Gesto čtyři"
+            },
+            "gesture_high_five": {
+                "name": "Gesto plácnutí"
+            },
+            "gesture_finger_gun": {
+                "name": "Gesto prstová pistole"
+            },
+            "gesture_ok": {
+                "name": "Gesto OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Gesto znak V oběma rukama"
+            },
+            "gesture_four_both_hands": {
+                "name": "Gesto čtyři oběma rukama"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Gesto plácnutí oběma rukama"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Gesto prstová pistole oběma rukama"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Gesto OK oběma rukama"
+            },
+            "doorbell_ring": {
+                "name": "Zvonek"
+            },
+            "detection_area": {
+                "name": "Detekční zóna {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Časové pásmo brány"
+            },
+            "night_light_configuration": {
+                "name": "Konfigurace nočního světla"
+            },
+            "face_recognition_event": {
+                "name": "Událost rozpoznání obličeje"
+            },
+            "stranger_face_event": {
+                "name": "Událost cizí tváře"
+            },
+            "door_event": {
+                "name": "Událost dveří",
+                "state": {
+                    "door_opened": "Dveře otevřeny",
+                    "door_closed": "Dveře zavřeny",
+                    "timeout_without_closing": "Vypršení času bez zavření",
+                    "knock_on_the_door": "Zaklepání na dveře",
+                    "attempted_break_in": "Pokus o vloupání",
+                    "door_ajar": "Dveře pootevřené"
+                }
+            },
+            "lock_state": {
+                "name": "Stav zámku",
+                "state": {
+                    "door_cannot_be_closed": "Dveře nelze zavřít",
+                    "door_is_open": "Dveře jsou otevřené",
+                    "door_closed_handle_not_lifted": "Dveře zavřené, ale klika není zvednutá",
+                    "door_is_locked": "Dveře jsou zamčené",
+                    "door_is_locked_by_night_latch_knob": "Dveře zamčené noční západkou",
+                    "door_is_unlocked": "Dveře jsou odemčené",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Dveře zamčené přední klikou a noční západkou",
+                    "door_is_almost_closed": "Dveře jsou téměř zavřené"
+                }
+            },
+            "open_door_method": {
+                "name": "Způsob otevření dveří",
+                "state": {
+                    "fingerprint_unlock": "Odemčení otiskem prstu",
+                    "permanent_password_unlock": "Odemčení trvalým heslem",
+                    "nfc_unlock": "Odemčení NFC",
+                    "bluetooth_unlock": "Odemčení Bluetooth",
+                    "temporary_password_unlock": "Odemčení dočasným heslem",
+                    "mechanical_key_unlock": "Odemčení mechanickým klíčem",
+                    "dual_authentication_unlock": "Odemčení dvojitým ověřením",
+                    "duress_fingerprint_unlock": "Odemčení nouzovým otiskem",
+                    "homekit_unlock": "Odemčení HomeKit",
+                    "face_unlock": "Odemčení obličejem",
+                    "aiot_remote_unlock": "Vzdálené odemčení AIoT",
+                    "google_password_unlock": "Odemčení heslem Google",
+                    "outdoor_unlock": "Venkovní odemčení"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "ID uživatele otisku"
+            },
+            "user_id_password": {
+                "name": "ID uživatele hesla"
+            },
+            "user_id_nfc": {
+                "name": "ID uživatele NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "ID uživatele HomeKit Bluetooth"
+            },
+            "user_id_temporary_password": {
+                "name": "ID uživatele dočasného hesla"
+            },
+            "people_counting": {
+                "name": "Počítání osob"
+            },
+            "people_counting_per_minute": {
+                "name": "Počítání osob (za minutu)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Počet osob v celé oblasti (10 s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Počet osob zóny {index} (10 s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Počet osob zóny {index} (za minutu)"
+            },
+            "heart_rate": {
+                "name": "Tepová frekvence"
+            },
+            "respiration_rate": {
+                "name": "Dechová frekvence"
+            },
+            "body_movement": {
+                "name": "Pohyb těla"
+            },
+            "sleep_state": {
+                "name": "Stav spánku"
+            },
+            "operating_mode": {
+                "name": "Provozní režim",
+                "state": {
+                    "zone_detection": "Detekce zóny",
+                    "fall_detection": "Detekce pádu",
+                    "sleep_monitoring": "Sledování spánku"
+                }
+            },
+            "view_zoom": {
+                "name": "Přiblížení zobrazení",
+                "state": {
+                    "full": "Plný",
+                    "adaptive": "Adaptivní"
+                }
+            },
+            "mounting_position": {
+                "name": "Pozice montáže",
+                "state": {
+                    "wall": "Stěna",
+                    "left_corner": "Levý roh",
+                    "right_corner": "Pravý roh"
+                }
+            },
+            "installation_angle": {
+                "name": "Úhel instalace",
+                "state": {
+                    "face_up": "Lícem nahoru",
+                    "oblique": "Šikmo",
+                    "horizontal": "Vodorovně",
+                    "face_down": "Lícem dolů"
+                }
+            },
+            "attitude_status": {
+                "name": "Stav polohy"
+            },
+            "presence_sensitivity": {
+                "name": "Citlivost přítomnosti",
+                "state": {
+                    "low": "Nízká",
+                    "medium": "Střední",
+                    "high": "Vysoká"
+                }
+            },
+            "proximity_distance": {
+                "name": "Vzdálenost přiblížení",
+                "state": {
+                    "far": "Daleko",
+                    "medium": "Střední",
+                    "close": "Blízko"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Citlivost detekce pádu",
+                "state": {
+                    "low": "Nízká",
+                    "medium": "Střední",
+                    "high": "Vysoká"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Obrátit směr souřadnic",
+                "state": {
+                    "disable": "Zakázáno",
+                    "enable": "Povoleno",
+                    "auto": "Automaticky"
+                }
+            },
+            "detection_direction": {
+                "name": "Směr detekce",
+                "state": {
+                    "default": "Výchozí",
+                    "left_right": "Vlevo/Vpravo"
+                }
+            },
+            "ai_person_detection": {
+                "name": "AI detekce osob",
+                "state": {
+                    "disable": "Zakázáno",
+                    "enable": "Povoleno"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Režim proti světelnému znečištění",
+                "state": {
+                    "disable": "Zakázáno",
+                    "enable": "Povoleno"
+                }
+            },
+            "activity_status": {
+                "name": "Stav aktivity",
+                "state": {
+                    "unoccupied": "Neobsazeno",
+                    "moving": "Pohyb",
+                    "stationary": "Nehybný"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Video"
+            },
+            "detect_human": {
+                "name": "Detekce člověka"
+            },
+            "detect_pet": {
+                "name": "Detekce mazlíčka"
+            },
+            "detect_gesture": {
+                "name": "Detekce gesta"
+            },
+            "detect_face": {
+                "name": "Detekce obličeje"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Ochrana proti smazání podzařízení"
+            },
+            "sound_detection": {
+                "name": "Detekce zvuku"
+            },
+            "timed_sleep": {
+                "name": "Časovaný spánek"
+            },
+            "motion_push": {
+                "name": "Push pohybu"
+            },
+            "motion_detection": {
+                "name": "Detekce pohybu"
+            },
+            "indicator_light": {
+                "name": "Kontrolka"
+            },
+            "timelapse_push": {
+                "name": "Push časosběru"
+            },
+            "sound_push": {
+                "name": "Push zvuku"
+            },
+            "device_offline_push": {
+                "name": "Push zařízení offline"
+            },
+            "motion_recording": {
+                "name": "Záznam pohybu"
+            },
+            "timelapse": {
+                "name": "Časosběr"
+            },
+            "sound_recording": {
+                "name": "Záznam zvuku"
+            },
+            "camera": {
+                "name": "Kamera"
+            },
+            "high_temp_alarm": {
+                "name": "Alarm vysoké teploty"
+            },
+            "face_recognition_push": {
+                "name": "Push rozpoznání obličeje"
+            },
+            "scheduled_sleep": {
+                "name": "Naplánovaný spánek"
+            },
+            "anti_tamper_alarm": {
+                "name": "Alarm proti manipulaci"
+            },
+            "face_recording": {
+                "name": "Záznam obličeje"
+            },
+            "doorbell_notification": {
+                "name": "Oznámení zvonku"
+            },
+            "low_temp_alarm": {
+                "name": "Alarm nízké teploty"
+            },
+            "doorbell_recording": {
+                "name": "Záznam zvonku"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Hlasitost"
+            },
+            "system_volume": {
+                "name": "Hlasitost systému"
+            },
+            "alarm_volume": {
+                "name": "Hlasitost alarmu"
+            },
+            "doorbell_volume": {
+                "name": "Hlasitost zvonku"
+            },
+            "alarm_duration": {
+                "name": "Doba trvání alarmu"
+            },
+            "doorbell_duration": {
+                "name": "Doba trvání zvonku"
+            },
+            "music_volume": {
+                "name": "Hlasitost hudby"
+            },
+            "alarm_clock_volume": {
+                "name": "Hlasitost budíku"
+            },
+            "night_light_brightness": {
+                "name": "Jas nočního světla"
+            },
+            "arming_delay_time": {
+                "name": "Doba zpoždění aktivace"
+            },
+            "camera_volume": {
+                "name": "Hlasitost kamery"
+            },
+            "face_recognition_interval": {
+                "name": "Interval rozpoznání obličeje"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Jazyk brány",
+                "state": {
+                    "chinese": "Čínština",
+                    "english": "Angličtina"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Vyzvánění alarmu",
+                "state": {
+                    "default": "Výchozí",
+                    "police_car_1": "Zvuk policejního auta 1",
+                    "police_car_2": "Zvuk policejního auta 2",
+                    "safety_accident": "Zvuk nehody",
+                    "missile_countdown": "Odpočet rakety",
+                    "ghost_scream": "Křik ducha",
+                    "sniper_rifle": "Odstřelovací puška",
+                    "battle": "Zvuk bitvy",
+                    "air_raid_alarm": "Poplach náletu",
+                    "dog_barking": "Štěkání psa"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Vyzvánění zvonku",
+                "state": {
+                    "default": "Výchozí",
+                    "index_0": "Index 0",
+                    "index_1": "Index 1",
+                    "index_2": "Index 2",
+                    "index_3": "Index 3",
+                    "index_4": "Index 4",
+                    "index_5": "Index 5",
+                    "index_6": "Index 6",
+                    "index_7": "Index 7",
+                    "index_8": "Index 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Překlopení obrazovky",
+                "state": {
+                    "normal": "Normální",
+                    "flip_horizontally": "Překlopit vodorovně",
+                    "flip_vertically": "Překlopit svisle",
+                    "flip_horizontally_and_vertically": "Překlopit vodorovně i svisle"
+                }
+            },
+            "camera_mode": {
+                "name": "Režim kamery",
+                "state": {
+                    "off": "Vypnuto",
+                    "on": "Zapnuto",
+                    "always_on": "Vždy zapnuto"
+                }
+            },
+            "work_mode": {
+                "name": "Pracovní režim",
+                "state": {
+                    "radar_infrared": "Radar + Infračervený",
+                    "radar_only": "Pouze radar",
+                    "infrared_only": "Pouze infračervený"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Nahoru"
+            },
+            "ptz_down": {
+                "name": "Dolů"
+            },
+            "ptz_left": {
+                "name": "Doleva"
+            },
+            "ptz_right": {
+                "name": "Doprava"
+            },
+            "ring_alarm_bell": {
+                "name": "Spustit zvonek alarmu"
+            },
+            "restart_device": {
+                "name": "Restartovat zařízení"
+            },
+            "restart_coordinator": {
+                "name": "Restartovat koordinátor"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/de.json
+++ b/custom_components/ha_aqara_devices/translations/de.json
@@ -32,18 +32,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Nachtsicht" },
-            "gesture_v_sign": { "name": "Geste V-Zeichen" },
-            "gesture_four": { "name": "Geste Vier" },
-            "gesture_high_five": { "name": "Geste High Five" },
-            "gesture_finger_gun": { "name": "Geste Fingerpistole" },
-            "gesture_ok": { "name": "Geste OK" },
-            "gesture_v_sign_both_hands": { "name": "Geste V-Zeichen mit beiden Haenden" },
-            "gesture_four_both_hands": { "name": "Geste Vier mit beiden Haenden" },
-            "gesture_high_five_both_hands": { "name": "Geste High Five mit beiden Haenden" },
-            "gesture_finger_gun_both_hands": { "name": "Geste Fingerpistole mit beiden Haenden" },
-            "gesture_ok_both_hands": { "name": "Geste OK mit beiden Haenden" },
-            "motion_event": { "name": "Bewegungsereignis" }
+            "night_vision": {
+                "name": "Nachtsicht"
+            },
+            "motion_event": {
+                "name": "Bewegungsereignis"
+            },
+            "gesture_v_sign": {
+                "name": "Geste V-Zeichen"
+            },
+            "gesture_four": {
+                "name": "Geste Vier"
+            },
+            "gesture_high_five": {
+                "name": "Geste High Five"
+            },
+            "gesture_finger_gun": {
+                "name": "Geste Fingerpistole"
+            },
+            "gesture_ok": {
+                "name": "Geste OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Geste V-Zeichen beide Hände"
+            },
+            "gesture_four_both_hands": {
+                "name": "Geste Vier beide Hände"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Geste High Five beide Hände"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Geste Fingerpistole beide Hände"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Geste OK beide Hände"
+            },
+            "doorbell_ring": {
+                "name": "Türklingel"
+            },
+            "detection_area": {
+                "name": "Erkennungsbereich {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Gateway-Zeitzone"
+            },
+            "night_light_configuration": {
+                "name": "Nachtlicht-Konfiguration"
+            },
+            "face_recognition_event": {
+                "name": "Gesichtserkennungsereignis"
+            },
+            "stranger_face_event": {
+                "name": "Fremdgesicht-Ereignis"
+            },
+            "door_event": {
+                "name": "Türereignis",
+                "state": {
+                    "door_opened": "Tür geöffnet",
+                    "door_closed": "Tür geschlossen",
+                    "timeout_without_closing": "Zeitüberschreitung ohne Schließen",
+                    "knock_on_the_door": "Klopfen an der Tür",
+                    "attempted_break_in": "Einbruchsversuch",
+                    "door_ajar": "Tür angelehnt"
+                }
+            },
+            "lock_state": {
+                "name": "Türschlossstatus",
+                "state": {
+                    "door_cannot_be_closed": "Tür kann nicht geschlossen werden",
+                    "door_is_open": "Tür ist offen",
+                    "door_closed_handle_not_lifted": "Tür geschlossen, aber Griff nicht angehoben",
+                    "door_is_locked": "Tür ist verriegelt",
+                    "door_is_locked_by_night_latch_knob": "Tür durch Nachtriegelknopf verriegelt",
+                    "door_is_unlocked": "Tür ist entriegelt",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Tür durch Frontgriff und Nachtriegelknopf verriegelt",
+                    "door_is_almost_closed": "Tür ist fast geschlossen"
+                }
+            },
+            "open_door_method": {
+                "name": "Türöffnungsmethode",
+                "state": {
+                    "fingerprint_unlock": "Entriegelung per Fingerabdruck",
+                    "permanent_password_unlock": "Entriegelung per Dauerpasswort",
+                    "nfc_unlock": "Entriegelung per NFC",
+                    "bluetooth_unlock": "Entriegelung per Bluetooth",
+                    "temporary_password_unlock": "Entriegelung per temporärem Passwort",
+                    "mechanical_key_unlock": "Entriegelung per mechanischem Schlüssel",
+                    "dual_authentication_unlock": "Entriegelung per Zwei-Faktor-Authentifizierung",
+                    "duress_fingerprint_unlock": "Entriegelung per Notfall-Fingerabdruck",
+                    "homekit_unlock": "Entriegelung per HomeKit",
+                    "face_unlock": "Entriegelung per Gesichtserkennung",
+                    "aiot_remote_unlock": "AIoT-Fernentriegelung",
+                    "google_password_unlock": "Entriegelung per Google-Passwort",
+                    "outdoor_unlock": "Entriegelung von außen"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "Benutzer-ID Fingerabdruck"
+            },
+            "user_id_password": {
+                "name": "Benutzer-ID Passwort"
+            },
+            "user_id_nfc": {
+                "name": "Benutzer-ID NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "HomeKit-Bluetooth-Benutzer-ID"
+            },
+            "user_id_temporary_password": {
+                "name": "Benutzer-ID temporäres Passwort"
+            },
+            "people_counting": {
+                "name": "Personenzählung"
+            },
+            "people_counting_per_minute": {
+                "name": "Personenzählung (pro Minute)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Personenzahl gesamter Bereich (10 s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Personenzahl Zone {index} (10 s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Personenzahl Zone {index} (pro Minute)"
+            },
+            "heart_rate": {
+                "name": "Herzfrequenz"
+            },
+            "respiration_rate": {
+                "name": "Atemfrequenz"
+            },
+            "body_movement": {
+                "name": "Körperbewegung"
+            },
+            "sleep_state": {
+                "name": "Schlafzustand"
+            },
+            "operating_mode": {
+                "name": "Betriebsmodus",
+                "state": {
+                    "zone_detection": "Zonenerkennung",
+                    "fall_detection": "Sturzerkennung",
+                    "sleep_monitoring": "Schlafüberwachung"
+                }
+            },
+            "view_zoom": {
+                "name": "Ansichtszoom",
+                "state": {
+                    "full": "Voll",
+                    "adaptive": "Adaptiv"
+                }
+            },
+            "mounting_position": {
+                "name": "Montageposition",
+                "state": {
+                    "wall": "Wand",
+                    "left_corner": "Linke Ecke",
+                    "right_corner": "Rechte Ecke"
+                }
+            },
+            "installation_angle": {
+                "name": "Installationswinkel",
+                "state": {
+                    "face_up": "Nach oben",
+                    "oblique": "Schräg",
+                    "horizontal": "Horizontal",
+                    "face_down": "Nach unten"
+                }
+            },
+            "attitude_status": {
+                "name": "Lagestatus"
+            },
+            "presence_sensitivity": {
+                "name": "Anwesenheitsempfindlichkeit",
+                "state": {
+                    "low": "Niedrig",
+                    "medium": "Mittel",
+                    "high": "Hoch"
+                }
+            },
+            "proximity_distance": {
+                "name": "Näherungsabstand",
+                "state": {
+                    "far": "Weit",
+                    "medium": "Mittel",
+                    "close": "Nah"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Sturzerkennungsempfindlichkeit",
+                "state": {
+                    "low": "Niedrig",
+                    "medium": "Mittel",
+                    "high": "Hoch"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Koordinatenrichtung umkehren",
+                "state": {
+                    "disable": "Deaktiviert",
+                    "enable": "Aktiviert",
+                    "auto": "Auto"
+                }
+            },
+            "detection_direction": {
+                "name": "Erkennungsrichtung",
+                "state": {
+                    "default": "Standard",
+                    "left_right": "Links/Rechts"
+                }
+            },
+            "ai_person_detection": {
+                "name": "KI-Personenerkennung",
+                "state": {
+                    "disable": "Deaktiviert",
+                    "enable": "Aktiviert"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Anti-Lichtverschmutzungsmodus",
+                "state": {
+                    "disable": "Deaktiviert",
+                    "enable": "Aktiviert"
+                }
+            },
+            "activity_status": {
+                "name": "Aktivitätsstatus",
+                "state": {
+                    "unoccupied": "Unbesetzt",
+                    "moving": "In Bewegung",
+                    "stationary": "Stationär"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Video"
+            },
+            "detect_human": {
+                "name": "Mensch erkennen"
+            },
+            "detect_pet": {
+                "name": "Haustier erkennen"
+            },
+            "detect_gesture": {
+                "name": "Geste erkennen"
+            },
+            "detect_face": {
+                "name": "Gesicht erkennen"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Löschschutz für Untergeräte"
+            },
+            "sound_detection": {
+                "name": "Geräuscherkennung"
+            },
+            "timed_sleep": {
+                "name": "Zeitgesteuerter Ruhemodus"
+            },
+            "motion_push": {
+                "name": "Bewegungs-Push"
+            },
+            "motion_detection": {
+                "name": "Bewegungserkennung"
+            },
+            "indicator_light": {
+                "name": "Anzeigeleuchte"
+            },
+            "timelapse_push": {
+                "name": "Zeitraffer-Push"
+            },
+            "sound_push": {
+                "name": "Geräusch-Push"
+            },
+            "device_offline_push": {
+                "name": "Gerät-Offline-Push"
+            },
+            "motion_recording": {
+                "name": "Bewegungsaufnahme"
+            },
+            "timelapse": {
+                "name": "Zeitraffer"
+            },
+            "sound_recording": {
+                "name": "Tonaufnahme"
+            },
+            "camera": {
+                "name": "Kamera"
+            },
+            "high_temp_alarm": {
+                "name": "Hochtemperaturalarm"
+            },
+            "face_recognition_push": {
+                "name": "Gesichtserkennungs-Push"
+            },
+            "scheduled_sleep": {
+                "name": "Geplanter Ruhemodus"
+            },
+            "anti_tamper_alarm": {
+                "name": "Manipulationsalarm"
+            },
+            "face_recording": {
+                "name": "Gesichtsaufnahme"
+            },
+            "doorbell_notification": {
+                "name": "Türklingelbenachrichtigung"
+            },
+            "low_temp_alarm": {
+                "name": "Niedrigtemperaturalarm"
+            },
+            "doorbell_recording": {
+                "name": "Türklingelaufnahme"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Lautstärke"
+            },
+            "system_volume": {
+                "name": "Systemlautstärke"
+            },
+            "alarm_volume": {
+                "name": "Alarmlautstärke"
+            },
+            "doorbell_volume": {
+                "name": "Türklingellautstärke"
+            },
+            "alarm_duration": {
+                "name": "Alarmdauer"
+            },
+            "doorbell_duration": {
+                "name": "Türklingeldauer"
+            },
+            "music_volume": {
+                "name": "Musiklautstärke"
+            },
+            "alarm_clock_volume": {
+                "name": "Weckerlautstärke"
+            },
+            "night_light_brightness": {
+                "name": "Nachtlichthelligkeit"
+            },
+            "arming_delay_time": {
+                "name": "Scharfschaltungsverzögerung"
+            },
+            "camera_volume": {
+                "name": "Kameralautstärke"
+            },
+            "face_recognition_interval": {
+                "name": "Gesichtserkennungsintervall"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Gateway-Sprache",
+                "state": {
+                    "chinese": "Chinesisch",
+                    "english": "Englisch"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Alarmklingelton",
+                "state": {
+                    "default": "Standard",
+                    "police_car_1": "Polizeiwagen-Ton 1",
+                    "police_car_2": "Polizeiwagen-Ton 2",
+                    "safety_accident": "Sicherheitsunfallton",
+                    "missile_countdown": "Raketen-Countdown",
+                    "ghost_scream": "Geisterschrei",
+                    "sniper_rifle": "Scharfschützengewehr",
+                    "battle": "Kampfgeräusch",
+                    "air_raid_alarm": "Luftangriffsalarm",
+                    "dog_barking": "Hundebellen"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Türklingelton",
+                "state": {
+                    "default": "Standard",
+                    "index_0": "Index 0",
+                    "index_1": "Index 1",
+                    "index_2": "Index 2",
+                    "index_3": "Index 3",
+                    "index_4": "Index 4",
+                    "index_5": "Index 5",
+                    "index_6": "Index 6",
+                    "index_7": "Index 7",
+                    "index_8": "Index 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Bildschirm spiegeln",
+                "state": {
+                    "normal": "Normal",
+                    "flip_horizontally": "Horizontal spiegeln",
+                    "flip_vertically": "Vertikal spiegeln",
+                    "flip_horizontally_and_vertically": "Horizontal und vertikal spiegeln"
+                }
+            },
+            "camera_mode": {
+                "name": "Kameramodus",
+                "state": {
+                    "off": "Aus",
+                    "on": "Ein",
+                    "always_on": "Immer ein"
+                }
+            },
+            "work_mode": {
+                "name": "Arbeitsmodus",
+                "state": {
+                    "radar_infrared": "Radar + Infrarot",
+                    "radar_only": "Nur Radar",
+                    "infrared_only": "Nur Infrarot"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Hoch"
+            },
+            "ptz_down": {
+                "name": "Runter"
+            },
+            "ptz_left": {
+                "name": "Links"
+            },
+            "ptz_right": {
+                "name": "Rechts"
+            },
+            "ring_alarm_bell": {
+                "name": "Alarmglocke läuten"
+            },
+            "restart_device": {
+                "name": "Gerät neu starten"
+            },
+            "restart_coordinator": {
+                "name": "Koordinator neu starten"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/en.json
+++ b/custom_components/ha_aqara_devices/translations/en.json
@@ -59,18 +59,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Night vision" },
-            "gesture_v_sign": { "name": "Gesture V sign" },
-            "gesture_four": { "name": "Gesture Four" },
-            "gesture_high_five": { "name": "Gesture High Five" },
-            "gesture_finger_gun": { "name": "Gesture Finger Gun" },
-            "gesture_ok": { "name": "Gesture OK" },
-            "gesture_v_sign_both_hands": { "name": "Gesture V sign both hands" },
-            "gesture_four_both_hands": { "name": "Gesture Four both hands" },
-            "gesture_high_five_both_hands": { "name": "Gesture High Five both hands" },
-            "gesture_finger_gun_both_hands": { "name": "Gesture Finger Gun both hands" },
-            "gesture_ok_both_hands": { "name": "Gesture OK both hands" },
-            "motion_event": { "name": "Motion Event" }
+            "night_vision": {
+                "name": "Night vision"
+            },
+            "motion_event": {
+                "name": "Motion Event"
+            },
+            "gesture_v_sign": {
+                "name": "Gesture V sign"
+            },
+            "gesture_four": {
+                "name": "Gesture Four"
+            },
+            "gesture_high_five": {
+                "name": "Gesture High Five"
+            },
+            "gesture_finger_gun": {
+                "name": "Gesture Finger Gun"
+            },
+            "gesture_ok": {
+                "name": "Gesture OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Gesture V sign both hands"
+            },
+            "gesture_four_both_hands": {
+                "name": "Gesture Four both hands"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Gesture High Five both hands"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Gesture Finger Gun both hands"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Gesture OK both hands"
+            },
+            "doorbell_ring": {
+                "name": "Doorbell Ring"
+            },
+            "detection_area": {
+                "name": "Detection Area {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Gateway Time Zone"
+            },
+            "night_light_configuration": {
+                "name": "Night Light Configuration"
+            },
+            "face_recognition_event": {
+                "name": "Face Recognition Event"
+            },
+            "stranger_face_event": {
+                "name": "Stranger Face Event"
+            },
+            "door_event": {
+                "name": "Door Event",
+                "state": {
+                    "door_opened": "Door opened",
+                    "door_closed": "Door closed",
+                    "timeout_without_closing": "Timeout without closing",
+                    "knock_on_the_door": "Knock on the door",
+                    "attempted_break_in": "Attempted break-in",
+                    "door_ajar": "Door ajar"
+                }
+            },
+            "lock_state": {
+                "name": "Door Lock Status",
+                "state": {
+                    "door_cannot_be_closed": "Door can't be closed",
+                    "door_is_open": "Door is open",
+                    "door_closed_handle_not_lifted": "Door is closed but front handle is not lifted",
+                    "door_is_locked": "Door is locked",
+                    "door_is_locked_by_night_latch_knob": "Door is locked by night latch knob",
+                    "door_is_unlocked": "Door is unlocked",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Door is locked by front handle and night latch knob",
+                    "door_is_almost_closed": "Door is almost closed"
+                }
+            },
+            "open_door_method": {
+                "name": "Open Door Method",
+                "state": {
+                    "fingerprint_unlock": "Fingerprint unlock",
+                    "permanent_password_unlock": "Permanent password unlock",
+                    "nfc_unlock": "NFC unlock",
+                    "bluetooth_unlock": "Bluetooth unlock",
+                    "temporary_password_unlock": "Temporary password unlock",
+                    "mechanical_key_unlock": "Mechanical key unlock",
+                    "dual_authentication_unlock": "Dual authentication unlock",
+                    "duress_fingerprint_unlock": "Duress fingerprint unlock",
+                    "homekit_unlock": "HomeKit unlock",
+                    "face_unlock": "Face unlock",
+                    "aiot_remote_unlock": "AIoT remote unlock",
+                    "google_password_unlock": "Google password unlock",
+                    "outdoor_unlock": "Outdoor unlock"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "Fingerprint User ID"
+            },
+            "user_id_password": {
+                "name": "Password User ID"
+            },
+            "user_id_nfc": {
+                "name": "NFC User ID"
+            },
+            "user_id_ble_homekit": {
+                "name": "HomeKit Bluetooth User ID"
+            },
+            "user_id_temporary_password": {
+                "name": "Temporary Password User ID"
+            },
+            "people_counting": {
+                "name": "People Counting"
+            },
+            "people_counting_per_minute": {
+                "name": "People Counting (per minute)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Whole Area People Count (10s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Zone {index} People Count (10s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Zone {index} People Count (per minute)"
+            },
+            "heart_rate": {
+                "name": "Heart Rate"
+            },
+            "respiration_rate": {
+                "name": "Respiration Rate"
+            },
+            "body_movement": {
+                "name": "Body Movement"
+            },
+            "sleep_state": {
+                "name": "Sleep State"
+            },
+            "operating_mode": {
+                "name": "Operating Mode",
+                "state": {
+                    "zone_detection": "Zone detection",
+                    "fall_detection": "Fall detection",
+                    "sleep_monitoring": "Sleep monitoring"
+                }
+            },
+            "view_zoom": {
+                "name": "View Zoom",
+                "state": {
+                    "full": "Full",
+                    "adaptive": "Adaptive"
+                }
+            },
+            "mounting_position": {
+                "name": "Mounting Position",
+                "state": {
+                    "wall": "Wall",
+                    "left_corner": "Left corner",
+                    "right_corner": "Right corner"
+                }
+            },
+            "installation_angle": {
+                "name": "Installation Angle",
+                "state": {
+                    "face_up": "Face up",
+                    "oblique": "Oblique",
+                    "horizontal": "Horizontal",
+                    "face_down": "Face down"
+                }
+            },
+            "attitude_status": {
+                "name": "Attitude Status"
+            },
+            "presence_sensitivity": {
+                "name": "Presence Sensitivity",
+                "state": {
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
+                }
+            },
+            "proximity_distance": {
+                "name": "Proximity Distance",
+                "state": {
+                    "far": "Far",
+                    "medium": "Medium",
+                    "close": "Close"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Fall Detection Sensitivity",
+                "state": {
+                    "low": "Low",
+                    "medium": "Medium",
+                    "high": "High"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Reverse Coordinate Direction",
+                "state": {
+                    "disable": "Disabled",
+                    "enable": "Enabled",
+                    "auto": "Auto"
+                }
+            },
+            "detection_direction": {
+                "name": "Detection Direction",
+                "state": {
+                    "default": "Default",
+                    "left_right": "Left/Right"
+                }
+            },
+            "ai_person_detection": {
+                "name": "AI Person Detection",
+                "state": {
+                    "disable": "Disabled",
+                    "enable": "Enabled"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Anti-light Pollution Mode",
+                "state": {
+                    "disable": "Disabled",
+                    "enable": "Enabled"
+                }
+            },
+            "activity_status": {
+                "name": "Activity Status",
+                "state": {
+                    "unoccupied": "Unoccupied",
+                    "moving": "Moving",
+                    "stationary": "Stationary"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Video"
+            },
+            "detect_human": {
+                "name": "Detect Human"
+            },
+            "detect_pet": {
+                "name": "Detect Pet"
+            },
+            "detect_gesture": {
+                "name": "Detect Gesture"
+            },
+            "detect_face": {
+                "name": "Detect Face"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Sub-device Deletion Protection"
+            },
+            "sound_detection": {
+                "name": "Sound Detection"
+            },
+            "timed_sleep": {
+                "name": "Timed Sleep"
+            },
+            "motion_push": {
+                "name": "Motion Push"
+            },
+            "motion_detection": {
+                "name": "Motion Detection"
+            },
+            "indicator_light": {
+                "name": "Indicator Light"
+            },
+            "timelapse_push": {
+                "name": "Timelapse Push"
+            },
+            "sound_push": {
+                "name": "Sound Push"
+            },
+            "device_offline_push": {
+                "name": "Device Offline Push"
+            },
+            "motion_recording": {
+                "name": "Motion Recording"
+            },
+            "timelapse": {
+                "name": "Timelapse"
+            },
+            "sound_recording": {
+                "name": "Sound Recording"
+            },
+            "camera": {
+                "name": "Camera"
+            },
+            "high_temp_alarm": {
+                "name": "High Temperature Alarm"
+            },
+            "face_recognition_push": {
+                "name": "Face Recognition Push"
+            },
+            "scheduled_sleep": {
+                "name": "Scheduled Sleep"
+            },
+            "anti_tamper_alarm": {
+                "name": "Anti-Tamper Alarm"
+            },
+            "face_recording": {
+                "name": "Face Recording"
+            },
+            "doorbell_notification": {
+                "name": "Doorbell Notification"
+            },
+            "low_temp_alarm": {
+                "name": "Low Temperature Alarm"
+            },
+            "doorbell_recording": {
+                "name": "Doorbell Recording"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Volume"
+            },
+            "system_volume": {
+                "name": "System Volume"
+            },
+            "alarm_volume": {
+                "name": "Alarm Volume"
+            },
+            "doorbell_volume": {
+                "name": "Doorbell Volume"
+            },
+            "alarm_duration": {
+                "name": "Alarm Duration"
+            },
+            "doorbell_duration": {
+                "name": "Doorbell Duration"
+            },
+            "music_volume": {
+                "name": "Music Volume"
+            },
+            "alarm_clock_volume": {
+                "name": "Alarm Clock Volume"
+            },
+            "night_light_brightness": {
+                "name": "Night Light Brightness"
+            },
+            "arming_delay_time": {
+                "name": "Arming Delay Time"
+            },
+            "camera_volume": {
+                "name": "Camera Volume"
+            },
+            "face_recognition_interval": {
+                "name": "Face Recognition Interval"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Gateway Language",
+                "state": {
+                    "chinese": "Chinese",
+                    "english": "English"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Alarm Ringtone",
+                "state": {
+                    "default": "Default",
+                    "police_car_1": "Police car sound 1",
+                    "police_car_2": "Police car sound 2",
+                    "safety_accident": "Safety accident sound",
+                    "missile_countdown": "Missile countdown",
+                    "ghost_scream": "Ghost scream",
+                    "sniper_rifle": "Sniper rifle",
+                    "battle": "Battle sound",
+                    "air_raid_alarm": "Air raid alarm",
+                    "dog_barking": "Dog barking"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Doorbell Ringtone",
+                "state": {
+                    "default": "Default",
+                    "index_0": "Index 0",
+                    "index_1": "Index 1",
+                    "index_2": "Index 2",
+                    "index_3": "Index 3",
+                    "index_4": "Index 4",
+                    "index_5": "Index 5",
+                    "index_6": "Index 6",
+                    "index_7": "Index 7",
+                    "index_8": "Index 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Screen Flip",
+                "state": {
+                    "normal": "Normal",
+                    "flip_horizontally": "Flip Horizontally",
+                    "flip_vertically": "Flip Vertically",
+                    "flip_horizontally_and_vertically": "Flip Horizontally and Vertically"
+                }
+            },
+            "camera_mode": {
+                "name": "Camera Mode",
+                "state": {
+                    "off": "Off",
+                    "on": "On",
+                    "always_on": "Always On"
+                }
+            },
+            "work_mode": {
+                "name": "Work Mode",
+                "state": {
+                    "radar_infrared": "Radar + Infrared",
+                    "radar_only": "Radar only",
+                    "infrared_only": "Infrared only"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Up"
+            },
+            "ptz_down": {
+                "name": "Down"
+            },
+            "ptz_left": {
+                "name": "Left"
+            },
+            "ptz_right": {
+                "name": "Right"
+            },
+            "ring_alarm_bell": {
+                "name": "Ring Alarm Bell"
+            },
+            "restart_device": {
+                "name": "Restart Device"
+            },
+            "restart_coordinator": {
+                "name": "Restart Coordinator"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/es.json
+++ b/custom_components/ha_aqara_devices/translations/es.json
@@ -32,18 +32,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Vision nocturna" },
-            "gesture_v_sign": { "name": "Gesto signo V" },
-            "gesture_four": { "name": "Gesto cuatro" },
-            "gesture_high_five": { "name": "Gesto choca esos cinco" },
-            "gesture_finger_gun": { "name": "Gesto pistola con los dedos" },
-            "gesture_ok": { "name": "Gesto OK" },
-            "gesture_v_sign_both_hands": { "name": "Gesto signo V con ambas manos" },
-            "gesture_four_both_hands": { "name": "Gesto cuatro con ambas manos" },
-            "gesture_high_five_both_hands": { "name": "Gesto choca esos cinco con ambas manos" },
-            "gesture_finger_gun_both_hands": { "name": "Gesto pistola con ambas manos" },
-            "gesture_ok_both_hands": { "name": "Gesto OK con ambas manos" },
-            "motion_event": { "name": "Evento de movimiento" }
+            "night_vision": {
+                "name": "Visión nocturna"
+            },
+            "motion_event": {
+                "name": "Evento de movimiento"
+            },
+            "gesture_v_sign": {
+                "name": "Gesto signo V"
+            },
+            "gesture_four": {
+                "name": "Gesto Cuatro"
+            },
+            "gesture_high_five": {
+                "name": "Gesto Choca esos cinco"
+            },
+            "gesture_finger_gun": {
+                "name": "Gesto Pistola de dedos"
+            },
+            "gesture_ok": {
+                "name": "Gesto OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Gesto signo V ambas manos"
+            },
+            "gesture_four_both_hands": {
+                "name": "Gesto Cuatro ambas manos"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Gesto Choca esos cinco ambas manos"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Gesto Pistola de dedos ambas manos"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Gesto OK ambas manos"
+            },
+            "doorbell_ring": {
+                "name": "Timbre"
+            },
+            "detection_area": {
+                "name": "Área de detección {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Zona horaria de la puerta de enlace"
+            },
+            "night_light_configuration": {
+                "name": "Configuración de luz nocturna"
+            },
+            "face_recognition_event": {
+                "name": "Evento de reconocimiento facial"
+            },
+            "stranger_face_event": {
+                "name": "Evento de rostro desconocido"
+            },
+            "door_event": {
+                "name": "Evento de puerta",
+                "state": {
+                    "door_opened": "Puerta abierta",
+                    "door_closed": "Puerta cerrada",
+                    "timeout_without_closing": "Tiempo agotado sin cerrar",
+                    "knock_on_the_door": "Golpe en la puerta",
+                    "attempted_break_in": "Intento de allanamiento",
+                    "door_ajar": "Puerta entreabierta"
+                }
+            },
+            "lock_state": {
+                "name": "Estado de la cerradura",
+                "state": {
+                    "door_cannot_be_closed": "La puerta no se puede cerrar",
+                    "door_is_open": "La puerta está abierta",
+                    "door_closed_handle_not_lifted": "Puerta cerrada pero manilla no levantada",
+                    "door_is_locked": "La puerta está bloqueada",
+                    "door_is_locked_by_night_latch_knob": "Puerta bloqueada por el pomo de cierre nocturno",
+                    "door_is_unlocked": "La puerta está desbloqueada",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Puerta bloqueada por manilla frontal y pomo de cierre nocturno",
+                    "door_is_almost_closed": "La puerta está casi cerrada"
+                }
+            },
+            "open_door_method": {
+                "name": "Método de apertura",
+                "state": {
+                    "fingerprint_unlock": "Desbloqueo por huella",
+                    "permanent_password_unlock": "Desbloqueo por contraseña permanente",
+                    "nfc_unlock": "Desbloqueo NFC",
+                    "bluetooth_unlock": "Desbloqueo Bluetooth",
+                    "temporary_password_unlock": "Desbloqueo por contraseña temporal",
+                    "mechanical_key_unlock": "Desbloqueo con llave mecánica",
+                    "dual_authentication_unlock": "Desbloqueo con doble autenticación",
+                    "duress_fingerprint_unlock": "Desbloqueo por huella de coacción",
+                    "homekit_unlock": "Desbloqueo HomeKit",
+                    "face_unlock": "Desbloqueo facial",
+                    "aiot_remote_unlock": "Desbloqueo remoto AIoT",
+                    "google_password_unlock": "Desbloqueo con contraseña de Google",
+                    "outdoor_unlock": "Desbloqueo exterior"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "ID de usuario de huella"
+            },
+            "user_id_password": {
+                "name": "ID de usuario de contraseña"
+            },
+            "user_id_nfc": {
+                "name": "ID de usuario NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "ID de usuario Bluetooth HomeKit"
+            },
+            "user_id_temporary_password": {
+                "name": "ID de usuario de contraseña temporal"
+            },
+            "people_counting": {
+                "name": "Recuento de personas"
+            },
+            "people_counting_per_minute": {
+                "name": "Recuento de personas (por minuto)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Recuento de personas de toda el área (10 s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Recuento de personas zona {index} (10 s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Recuento de personas zona {index} (por minuto)"
+            },
+            "heart_rate": {
+                "name": "Frecuencia cardíaca"
+            },
+            "respiration_rate": {
+                "name": "Frecuencia respiratoria"
+            },
+            "body_movement": {
+                "name": "Movimiento corporal"
+            },
+            "sleep_state": {
+                "name": "Estado del sueño"
+            },
+            "operating_mode": {
+                "name": "Modo de funcionamiento",
+                "state": {
+                    "zone_detection": "Detección de zona",
+                    "fall_detection": "Detección de caídas",
+                    "sleep_monitoring": "Monitoreo del sueño"
+                }
+            },
+            "view_zoom": {
+                "name": "Zoom de vista",
+                "state": {
+                    "full": "Completo",
+                    "adaptive": "Adaptativo"
+                }
+            },
+            "mounting_position": {
+                "name": "Posición de montaje",
+                "state": {
+                    "wall": "Pared",
+                    "left_corner": "Esquina izquierda",
+                    "right_corner": "Esquina derecha"
+                }
+            },
+            "installation_angle": {
+                "name": "Ángulo de instalación",
+                "state": {
+                    "face_up": "Hacia arriba",
+                    "oblique": "Oblicuo",
+                    "horizontal": "Horizontal",
+                    "face_down": "Hacia abajo"
+                }
+            },
+            "attitude_status": {
+                "name": "Estado de orientación"
+            },
+            "presence_sensitivity": {
+                "name": "Sensibilidad de presencia",
+                "state": {
+                    "low": "Bajo",
+                    "medium": "Medio",
+                    "high": "Alto"
+                }
+            },
+            "proximity_distance": {
+                "name": "Distancia de proximidad",
+                "state": {
+                    "far": "Lejos",
+                    "medium": "Medio",
+                    "close": "Cerca"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Sensibilidad de detección de caídas",
+                "state": {
+                    "low": "Bajo",
+                    "medium": "Medio",
+                    "high": "Alto"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Invertir dirección de coordenadas",
+                "state": {
+                    "disable": "Desactivado",
+                    "enable": "Activado",
+                    "auto": "Automático"
+                }
+            },
+            "detection_direction": {
+                "name": "Dirección de detección",
+                "state": {
+                    "default": "Predeterminado",
+                    "left_right": "Izquierda/Derecha"
+                }
+            },
+            "ai_person_detection": {
+                "name": "Detección de personas con IA",
+                "state": {
+                    "disable": "Desactivado",
+                    "enable": "Activado"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Modo anti-contaminación lumínica",
+                "state": {
+                    "disable": "Desactivado",
+                    "enable": "Activado"
+                }
+            },
+            "activity_status": {
+                "name": "Estado de actividad",
+                "state": {
+                    "unoccupied": "Desocupado",
+                    "moving": "En movimiento",
+                    "stationary": "Estacionario"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Vídeo"
+            },
+            "detect_human": {
+                "name": "Detectar humano"
+            },
+            "detect_pet": {
+                "name": "Detectar mascota"
+            },
+            "detect_gesture": {
+                "name": "Detectar gesto"
+            },
+            "detect_face": {
+                "name": "Detectar rostro"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Protección contra eliminación de subdispositivos"
+            },
+            "sound_detection": {
+                "name": "Detección de sonido"
+            },
+            "timed_sleep": {
+                "name": "Suspensión programada"
+            },
+            "motion_push": {
+                "name": "Notificación de movimiento"
+            },
+            "motion_detection": {
+                "name": "Detección de movimiento"
+            },
+            "indicator_light": {
+                "name": "Luz indicadora"
+            },
+            "timelapse_push": {
+                "name": "Notificación de time-lapse"
+            },
+            "sound_push": {
+                "name": "Notificación de sonido"
+            },
+            "device_offline_push": {
+                "name": "Notificación de dispositivo desconectado"
+            },
+            "motion_recording": {
+                "name": "Grabación por movimiento"
+            },
+            "timelapse": {
+                "name": "Time-lapse"
+            },
+            "sound_recording": {
+                "name": "Grabación de sonido"
+            },
+            "camera": {
+                "name": "Cámara"
+            },
+            "high_temp_alarm": {
+                "name": "Alarma de temperatura alta"
+            },
+            "face_recognition_push": {
+                "name": "Notificación de reconocimiento facial"
+            },
+            "scheduled_sleep": {
+                "name": "Suspensión programada"
+            },
+            "anti_tamper_alarm": {
+                "name": "Alarma antimanipulación"
+            },
+            "face_recording": {
+                "name": "Grabación de rostro"
+            },
+            "doorbell_notification": {
+                "name": "Notificación de timbre"
+            },
+            "low_temp_alarm": {
+                "name": "Alarma de temperatura baja"
+            },
+            "doorbell_recording": {
+                "name": "Grabación de timbre"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Volumen"
+            },
+            "system_volume": {
+                "name": "Volumen del sistema"
+            },
+            "alarm_volume": {
+                "name": "Volumen de alarma"
+            },
+            "doorbell_volume": {
+                "name": "Volumen del timbre"
+            },
+            "alarm_duration": {
+                "name": "Duración de alarma"
+            },
+            "doorbell_duration": {
+                "name": "Duración del timbre"
+            },
+            "music_volume": {
+                "name": "Volumen de música"
+            },
+            "alarm_clock_volume": {
+                "name": "Volumen del despertador"
+            },
+            "night_light_brightness": {
+                "name": "Brillo de luz nocturna"
+            },
+            "arming_delay_time": {
+                "name": "Tiempo de retardo de armado"
+            },
+            "camera_volume": {
+                "name": "Volumen de la cámara"
+            },
+            "face_recognition_interval": {
+                "name": "Intervalo de reconocimiento facial"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Idioma de la puerta de enlace",
+                "state": {
+                    "chinese": "Chino",
+                    "english": "Inglés"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Tono de alarma",
+                "state": {
+                    "default": "Predeterminado",
+                    "police_car_1": "Sonido de coche de policía 1",
+                    "police_car_2": "Sonido de coche de policía 2",
+                    "safety_accident": "Sonido de accidente de seguridad",
+                    "missile_countdown": "Cuenta atrás de misil",
+                    "ghost_scream": "Grito de fantasma",
+                    "sniper_rifle": "Rifle de francotirador",
+                    "battle": "Sonido de batalla",
+                    "air_raid_alarm": "Alarma de ataque aéreo",
+                    "dog_barking": "Ladrido de perro"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Tono del timbre",
+                "state": {
+                    "default": "Predeterminado",
+                    "index_0": "Índice 0",
+                    "index_1": "Índice 1",
+                    "index_2": "Índice 2",
+                    "index_3": "Índice 3",
+                    "index_4": "Índice 4",
+                    "index_5": "Índice 5",
+                    "index_6": "Índice 6",
+                    "index_7": "Índice 7",
+                    "index_8": "Índice 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Volteo de pantalla",
+                "state": {
+                    "normal": "Normal",
+                    "flip_horizontally": "Voltear horizontalmente",
+                    "flip_vertically": "Voltear verticalmente",
+                    "flip_horizontally_and_vertically": "Voltear horizontal y verticalmente"
+                }
+            },
+            "camera_mode": {
+                "name": "Modo de cámara",
+                "state": {
+                    "off": "Apagado",
+                    "on": "Encendido",
+                    "always_on": "Siempre encendido"
+                }
+            },
+            "work_mode": {
+                "name": "Modo de trabajo",
+                "state": {
+                    "radar_infrared": "Radar + Infrarrojo",
+                    "radar_only": "Solo radar",
+                    "infrared_only": "Solo infrarrojo"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Arriba"
+            },
+            "ptz_down": {
+                "name": "Abajo"
+            },
+            "ptz_left": {
+                "name": "Izquierda"
+            },
+            "ptz_right": {
+                "name": "Derecha"
+            },
+            "ring_alarm_bell": {
+                "name": "Sonar alarma"
+            },
+            "restart_device": {
+                "name": "Reiniciar dispositivo"
+            },
+            "restart_coordinator": {
+                "name": "Reiniciar coordinador"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/fr.json
+++ b/custom_components/ha_aqara_devices/translations/fr.json
@@ -59,18 +59,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Vision nocturne" },
-            "gesture_v_sign": { "name": "Geste signe V" },
-            "gesture_four": { "name": "Geste quatre" },
-            "gesture_high_five": { "name": "Geste tape m'en cinq" },
-            "gesture_finger_gun": { "name": "Geste pistolet avec les doigts" },
-            "gesture_ok": { "name": "Geste OK" },
-            "gesture_v_sign_both_hands": { "name": "Geste signe V deux mains" },
-            "gesture_four_both_hands": { "name": "Geste quatre deux mains" },
-            "gesture_high_five_both_hands": { "name": "Geste tape m'en cinq deux mains" },
-            "gesture_finger_gun_both_hands": { "name": "Geste pistolet avec les doigts deux mains" },
-            "gesture_ok_both_hands": { "name": "Geste OK deux mains" },
-            "motion_event": { "name": "Evenement de mouvement" }
+            "night_vision": {
+                "name": "Vision nocturne"
+            },
+            "motion_event": {
+                "name": "Événement de mouvement"
+            },
+            "gesture_v_sign": {
+                "name": "Geste signe V"
+            },
+            "gesture_four": {
+                "name": "Geste Quatre"
+            },
+            "gesture_high_five": {
+                "name": "Geste Tape m'en cinq"
+            },
+            "gesture_finger_gun": {
+                "name": "Geste Pistolet à doigts"
+            },
+            "gesture_ok": {
+                "name": "Geste OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Geste signe V deux mains"
+            },
+            "gesture_four_both_hands": {
+                "name": "Geste Quatre deux mains"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Geste Tape m'en cinq deux mains"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Geste Pistolet à doigts deux mains"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Geste OK deux mains"
+            },
+            "doorbell_ring": {
+                "name": "Sonnette"
+            },
+            "detection_area": {
+                "name": "Zone de détection {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Fuseau horaire de la passerelle"
+            },
+            "night_light_configuration": {
+                "name": "Configuration de la veilleuse"
+            },
+            "face_recognition_event": {
+                "name": "Événement de reconnaissance faciale"
+            },
+            "stranger_face_event": {
+                "name": "Événement de visage inconnu"
+            },
+            "door_event": {
+                "name": "Événement de porte",
+                "state": {
+                    "door_opened": "Porte ouverte",
+                    "door_closed": "Porte fermée",
+                    "timeout_without_closing": "Expiration sans fermeture",
+                    "knock_on_the_door": "Coup frappé à la porte",
+                    "attempted_break_in": "Tentative d'effraction",
+                    "door_ajar": "Porte entrouverte"
+                }
+            },
+            "lock_state": {
+                "name": "État du verrou",
+                "state": {
+                    "door_cannot_be_closed": "La porte ne peut pas être fermée",
+                    "door_is_open": "La porte est ouverte",
+                    "door_closed_handle_not_lifted": "Porte fermée mais poignée non relevée",
+                    "door_is_locked": "La porte est verrouillée",
+                    "door_is_locked_by_night_latch_knob": "Porte verrouillée par le bouton de nuit",
+                    "door_is_unlocked": "La porte est déverrouillée",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Porte verrouillée par la poignée avant et le bouton de nuit",
+                    "door_is_almost_closed": "La porte est presque fermée"
+                }
+            },
+            "open_door_method": {
+                "name": "Méthode d'ouverture",
+                "state": {
+                    "fingerprint_unlock": "Déverrouillage par empreinte",
+                    "permanent_password_unlock": "Déverrouillage par mot de passe permanent",
+                    "nfc_unlock": "Déverrouillage NFC",
+                    "bluetooth_unlock": "Déverrouillage Bluetooth",
+                    "temporary_password_unlock": "Déverrouillage par mot de passe temporaire",
+                    "mechanical_key_unlock": "Déverrouillage par clé mécanique",
+                    "dual_authentication_unlock": "Déverrouillage par double authentification",
+                    "duress_fingerprint_unlock": "Déverrouillage par empreinte sous contrainte",
+                    "homekit_unlock": "Déverrouillage HomeKit",
+                    "face_unlock": "Déverrouillage par reconnaissance faciale",
+                    "aiot_remote_unlock": "Déverrouillage à distance AIoT",
+                    "google_password_unlock": "Déverrouillage par mot de passe Google",
+                    "outdoor_unlock": "Déverrouillage extérieur"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "ID utilisateur empreinte"
+            },
+            "user_id_password": {
+                "name": "ID utilisateur mot de passe"
+            },
+            "user_id_nfc": {
+                "name": "ID utilisateur NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "ID utilisateur Bluetooth HomeKit"
+            },
+            "user_id_temporary_password": {
+                "name": "ID utilisateur mot de passe temporaire"
+            },
+            "people_counting": {
+                "name": "Comptage de personnes"
+            },
+            "people_counting_per_minute": {
+                "name": "Comptage de personnes (par minute)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Comptage de personnes zone entière (10 s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Comptage de personnes zone {index} (10 s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Comptage de personnes zone {index} (par minute)"
+            },
+            "heart_rate": {
+                "name": "Fréquence cardiaque"
+            },
+            "respiration_rate": {
+                "name": "Fréquence respiratoire"
+            },
+            "body_movement": {
+                "name": "Mouvement corporel"
+            },
+            "sleep_state": {
+                "name": "État du sommeil"
+            },
+            "operating_mode": {
+                "name": "Mode de fonctionnement",
+                "state": {
+                    "zone_detection": "Détection de zone",
+                    "fall_detection": "Détection de chute",
+                    "sleep_monitoring": "Surveillance du sommeil"
+                }
+            },
+            "view_zoom": {
+                "name": "Zoom de la vue",
+                "state": {
+                    "full": "Complet",
+                    "adaptive": "Adaptatif"
+                }
+            },
+            "mounting_position": {
+                "name": "Position de montage",
+                "state": {
+                    "wall": "Mur",
+                    "left_corner": "Coin gauche",
+                    "right_corner": "Coin droit"
+                }
+            },
+            "installation_angle": {
+                "name": "Angle d'installation",
+                "state": {
+                    "face_up": "Vers le haut",
+                    "oblique": "Oblique",
+                    "horizontal": "Horizontal",
+                    "face_down": "Vers le bas"
+                }
+            },
+            "attitude_status": {
+                "name": "État d'orientation"
+            },
+            "presence_sensitivity": {
+                "name": "Sensibilité de présence",
+                "state": {
+                    "low": "Faible",
+                    "medium": "Moyen",
+                    "high": "Élevé"
+                }
+            },
+            "proximity_distance": {
+                "name": "Distance de proximité",
+                "state": {
+                    "far": "Loin",
+                    "medium": "Moyen",
+                    "close": "Proche"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Sensibilité de détection de chute",
+                "state": {
+                    "low": "Faible",
+                    "medium": "Moyen",
+                    "high": "Élevé"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Inverser la direction des coordonnées",
+                "state": {
+                    "disable": "Désactivé",
+                    "enable": "Activé",
+                    "auto": "Auto"
+                }
+            },
+            "detection_direction": {
+                "name": "Direction de détection",
+                "state": {
+                    "default": "Par défaut",
+                    "left_right": "Gauche/Droite"
+                }
+            },
+            "ai_person_detection": {
+                "name": "Détection de personne par IA",
+                "state": {
+                    "disable": "Désactivé",
+                    "enable": "Activé"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Mode anti-pollution lumineuse",
+                "state": {
+                    "disable": "Désactivé",
+                    "enable": "Activé"
+                }
+            },
+            "activity_status": {
+                "name": "État d'activité",
+                "state": {
+                    "unoccupied": "Inoccupé",
+                    "moving": "En mouvement",
+                    "stationary": "Immobile"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Vidéo"
+            },
+            "detect_human": {
+                "name": "Détecter humain"
+            },
+            "detect_pet": {
+                "name": "Détecter animal"
+            },
+            "detect_gesture": {
+                "name": "Détecter geste"
+            },
+            "detect_face": {
+                "name": "Détecter visage"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Protection contre la suppression des sous-appareils"
+            },
+            "sound_detection": {
+                "name": "Détection sonore"
+            },
+            "timed_sleep": {
+                "name": "Veille programmée"
+            },
+            "motion_push": {
+                "name": "Notification de mouvement"
+            },
+            "motion_detection": {
+                "name": "Détection de mouvement"
+            },
+            "indicator_light": {
+                "name": "Voyant lumineux"
+            },
+            "timelapse_push": {
+                "name": "Notification time-lapse"
+            },
+            "sound_push": {
+                "name": "Notification sonore"
+            },
+            "device_offline_push": {
+                "name": "Notification appareil hors ligne"
+            },
+            "motion_recording": {
+                "name": "Enregistrement sur mouvement"
+            },
+            "timelapse": {
+                "name": "Time-lapse"
+            },
+            "sound_recording": {
+                "name": "Enregistrement sonore"
+            },
+            "camera": {
+                "name": "Caméra"
+            },
+            "high_temp_alarm": {
+                "name": "Alarme de température élevée"
+            },
+            "face_recognition_push": {
+                "name": "Notification de reconnaissance faciale"
+            },
+            "scheduled_sleep": {
+                "name": "Veille planifiée"
+            },
+            "anti_tamper_alarm": {
+                "name": "Alarme anti-sabotage"
+            },
+            "face_recording": {
+                "name": "Enregistrement du visage"
+            },
+            "doorbell_notification": {
+                "name": "Notification de sonnette"
+            },
+            "low_temp_alarm": {
+                "name": "Alarme de température basse"
+            },
+            "doorbell_recording": {
+                "name": "Enregistrement de sonnette"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Volume"
+            },
+            "system_volume": {
+                "name": "Volume du système"
+            },
+            "alarm_volume": {
+                "name": "Volume de l'alarme"
+            },
+            "doorbell_volume": {
+                "name": "Volume de la sonnette"
+            },
+            "alarm_duration": {
+                "name": "Durée de l'alarme"
+            },
+            "doorbell_duration": {
+                "name": "Durée de la sonnette"
+            },
+            "music_volume": {
+                "name": "Volume de la musique"
+            },
+            "alarm_clock_volume": {
+                "name": "Volume du réveil"
+            },
+            "night_light_brightness": {
+                "name": "Luminosité de la veilleuse"
+            },
+            "arming_delay_time": {
+                "name": "Délai d'armement"
+            },
+            "camera_volume": {
+                "name": "Volume de la caméra"
+            },
+            "face_recognition_interval": {
+                "name": "Intervalle de reconnaissance faciale"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Langue de la passerelle",
+                "state": {
+                    "chinese": "Chinois",
+                    "english": "Anglais"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Sonnerie d'alarme",
+                "state": {
+                    "default": "Par défaut",
+                    "police_car_1": "Sirène de police 1",
+                    "police_car_2": "Sirène de police 2",
+                    "safety_accident": "Son d'accident de sécurité",
+                    "missile_countdown": "Compte à rebours de missile",
+                    "ghost_scream": "Cri de fantôme",
+                    "sniper_rifle": "Fusil de sniper",
+                    "battle": "Son de bataille",
+                    "air_raid_alarm": "Alarme de raid aérien",
+                    "dog_barking": "Aboiement de chien"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Sonnerie de la sonnette",
+                "state": {
+                    "default": "Par défaut",
+                    "index_0": "Index 0",
+                    "index_1": "Index 1",
+                    "index_2": "Index 2",
+                    "index_3": "Index 3",
+                    "index_4": "Index 4",
+                    "index_5": "Index 5",
+                    "index_6": "Index 6",
+                    "index_7": "Index 7",
+                    "index_8": "Index 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Retournement de l'écran",
+                "state": {
+                    "normal": "Normal",
+                    "flip_horizontally": "Retournement horizontal",
+                    "flip_vertically": "Retournement vertical",
+                    "flip_horizontally_and_vertically": "Retournement horizontal et vertical"
+                }
+            },
+            "camera_mode": {
+                "name": "Mode caméra",
+                "state": {
+                    "off": "Désactivé",
+                    "on": "Activé",
+                    "always_on": "Toujours activé"
+                }
+            },
+            "work_mode": {
+                "name": "Mode de travail",
+                "state": {
+                    "radar_infrared": "Radar + Infrarouge",
+                    "radar_only": "Radar uniquement",
+                    "infrared_only": "Infrarouge uniquement"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Haut"
+            },
+            "ptz_down": {
+                "name": "Bas"
+            },
+            "ptz_left": {
+                "name": "Gauche"
+            },
+            "ptz_right": {
+                "name": "Droite"
+            },
+            "ring_alarm_bell": {
+                "name": "Déclencher l'alarme"
+            },
+            "restart_device": {
+                "name": "Redémarrer l'appareil"
+            },
+            "restart_coordinator": {
+                "name": "Redémarrer le coordinateur"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/hu.json
+++ b/custom_components/ha_aqara_devices/translations/hu.json
@@ -32,18 +32,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Ejjellatas" },
-            "gesture_v_sign": { "name": "V jel kezmozdulat" },
-            "gesture_four": { "name": "Negyes kezmozdulat" },
-            "gesture_high_five": { "name": "Pacsi kezmozdulat" },
-            "gesture_finger_gun": { "name": "Pisztoly kezmozdulat" },
-            "gesture_ok": { "name": "OK kezmozdulat" },
-            "gesture_v_sign_both_hands": { "name": "V jel kezmozdulat ket kezzel" },
-            "gesture_four_both_hands": { "name": "Negyes kezmozdulat ket kezzel" },
-            "gesture_high_five_both_hands": { "name": "Pacsi kezmozdulat ket kezzel" },
-            "gesture_finger_gun_both_hands": { "name": "Pisztoly kezmozdulat ket kezzel" },
-            "gesture_ok_both_hands": { "name": "OK kezmozdulat ket kezzel" },
-            "motion_event": { "name": "Mozgasesemeny" }
+            "night_vision": {
+                "name": "Éjjellátó"
+            },
+            "motion_event": {
+                "name": "Mozgásesemény"
+            },
+            "gesture_v_sign": {
+                "name": "V-jel gesztus"
+            },
+            "gesture_four": {
+                "name": "Négyes gesztus"
+            },
+            "gesture_high_five": {
+                "name": "High five gesztus"
+            },
+            "gesture_finger_gun": {
+                "name": "Ujjpisztoly gesztus"
+            },
+            "gesture_ok": {
+                "name": "OK gesztus"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "V-jel gesztus két kézzel"
+            },
+            "gesture_four_both_hands": {
+                "name": "Négyes gesztus két kézzel"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "High five gesztus két kézzel"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Ujjpisztoly gesztus két kézzel"
+            },
+            "gesture_ok_both_hands": {
+                "name": "OK gesztus két kézzel"
+            },
+            "doorbell_ring": {
+                "name": "Csengetés"
+            },
+            "detection_area": {
+                "name": "Érzékelési terület {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Átjáró időzónája"
+            },
+            "night_light_configuration": {
+                "name": "Éjszakai fény beállítása"
+            },
+            "face_recognition_event": {
+                "name": "Arcfelismerési esemény"
+            },
+            "stranger_face_event": {
+                "name": "Idegen arc esemény"
+            },
+            "door_event": {
+                "name": "Ajtó esemény",
+                "state": {
+                    "door_opened": "Ajtó kinyitva",
+                    "door_closed": "Ajtó becsukva",
+                    "timeout_without_closing": "Időtúllépés zárás nélkül",
+                    "knock_on_the_door": "Kopogás az ajtón",
+                    "attempted_break_in": "Betörési kísérlet",
+                    "door_ajar": "Ajtó résnyire nyitva"
+                }
+            },
+            "lock_state": {
+                "name": "Ajtózár állapota",
+                "state": {
+                    "door_cannot_be_closed": "Az ajtó nem zárható",
+                    "door_is_open": "Az ajtó nyitva van",
+                    "door_closed_handle_not_lifted": "Ajtó becsukva, de a kilincs nincs felemelve",
+                    "door_is_locked": "Az ajtó zárva van",
+                    "door_is_locked_by_night_latch_knob": "Ajtó éjszakai retesz gombbal zárva",
+                    "door_is_unlocked": "Az ajtó nyitva (kireteszelve)",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Ajtó az első kilinccsel és éjszakai retesz gombbal zárva",
+                    "door_is_almost_closed": "Az ajtó majdnem becsukva"
+                }
+            },
+            "open_door_method": {
+                "name": "Ajtónyitási mód",
+                "state": {
+                    "fingerprint_unlock": "Ujjlenyomatos nyitás",
+                    "permanent_password_unlock": "Állandó jelszavas nyitás",
+                    "nfc_unlock": "NFC nyitás",
+                    "bluetooth_unlock": "Bluetooth nyitás",
+                    "temporary_password_unlock": "Ideiglenes jelszavas nyitás",
+                    "mechanical_key_unlock": "Mechanikus kulcsos nyitás",
+                    "dual_authentication_unlock": "Kétfaktoros nyitás",
+                    "duress_fingerprint_unlock": "Kényszer-ujjlenyomatos nyitás",
+                    "homekit_unlock": "HomeKit nyitás",
+                    "face_unlock": "Arcfelismeréses nyitás",
+                    "aiot_remote_unlock": "AIoT távoli nyitás",
+                    "google_password_unlock": "Google jelszavas nyitás",
+                    "outdoor_unlock": "Kültéri nyitás"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "Ujjlenyomat felhasználói azonosító"
+            },
+            "user_id_password": {
+                "name": "Jelszó felhasználói azonosító"
+            },
+            "user_id_nfc": {
+                "name": "NFC felhasználói azonosító"
+            },
+            "user_id_ble_homekit": {
+                "name": "HomeKit Bluetooth felhasználói azonosító"
+            },
+            "user_id_temporary_password": {
+                "name": "Ideiglenes jelszó felhasználói azonosító"
+            },
+            "people_counting": {
+                "name": "Emberszámlálás"
+            },
+            "people_counting_per_minute": {
+                "name": "Emberszámlálás (percenként)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Teljes terület emberszám (10 mp)"
+            },
+            "zone_people_count_10s": {
+                "name": "{index}. zóna emberszám (10 mp)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "{index}. zóna emberszám (percenként)"
+            },
+            "heart_rate": {
+                "name": "Pulzusszám"
+            },
+            "respiration_rate": {
+                "name": "Légzésszám"
+            },
+            "body_movement": {
+                "name": "Testmozgás"
+            },
+            "sleep_state": {
+                "name": "Alvási állapot"
+            },
+            "operating_mode": {
+                "name": "Üzemmód",
+                "state": {
+                    "zone_detection": "Zónaérzékelés",
+                    "fall_detection": "Esésérzékelés",
+                    "sleep_monitoring": "Alvásfigyelés"
+                }
+            },
+            "view_zoom": {
+                "name": "Nézet nagyítása",
+                "state": {
+                    "full": "Teljes",
+                    "adaptive": "Adaptív"
+                }
+            },
+            "mounting_position": {
+                "name": "Felszerelési pozíció",
+                "state": {
+                    "wall": "Fal",
+                    "left_corner": "Bal sarok",
+                    "right_corner": "Jobb sarok"
+                }
+            },
+            "installation_angle": {
+                "name": "Telepítési szög",
+                "state": {
+                    "face_up": "Felfelé",
+                    "oblique": "Ferde",
+                    "horizontal": "Vízszintes",
+                    "face_down": "Lefelé"
+                }
+            },
+            "attitude_status": {
+                "name": "Helyzet állapota"
+            },
+            "presence_sensitivity": {
+                "name": "Jelenlét érzékenysége",
+                "state": {
+                    "low": "Alacsony",
+                    "medium": "Közepes",
+                    "high": "Magas"
+                }
+            },
+            "proximity_distance": {
+                "name": "Közelségi távolság",
+                "state": {
+                    "far": "Távoli",
+                    "medium": "Közepes",
+                    "close": "Közeli"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Esésérzékelés érzékenysége",
+                "state": {
+                    "low": "Alacsony",
+                    "medium": "Közepes",
+                    "high": "Magas"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Koordináta-irány megfordítása",
+                "state": {
+                    "disable": "Letiltva",
+                    "enable": "Engedélyezve",
+                    "auto": "Automatikus"
+                }
+            },
+            "detection_direction": {
+                "name": "Érzékelési irány",
+                "state": {
+                    "default": "Alapértelmezett",
+                    "left_right": "Bal/Jobb"
+                }
+            },
+            "ai_person_detection": {
+                "name": "MI-személyérzékelés",
+                "state": {
+                    "disable": "Letiltva",
+                    "enable": "Engedélyezve"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Fényszennyezés elleni mód",
+                "state": {
+                    "disable": "Letiltva",
+                    "enable": "Engedélyezve"
+                }
+            },
+            "activity_status": {
+                "name": "Tevékenység állapota",
+                "state": {
+                    "unoccupied": "Üres",
+                    "moving": "Mozgásban",
+                    "stationary": "Mozdulatlan"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Videó"
+            },
+            "detect_human": {
+                "name": "Ember érzékelése"
+            },
+            "detect_pet": {
+                "name": "Háziállat érzékelése"
+            },
+            "detect_gesture": {
+                "name": "Gesztus érzékelése"
+            },
+            "detect_face": {
+                "name": "Arc érzékelése"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Aleszköz törlésvédelem"
+            },
+            "sound_detection": {
+                "name": "Hangérzékelés"
+            },
+            "timed_sleep": {
+                "name": "Időzített alvás"
+            },
+            "motion_push": {
+                "name": "Mozgás értesítés"
+            },
+            "motion_detection": {
+                "name": "Mozgásérzékelés"
+            },
+            "indicator_light": {
+                "name": "Jelzőfény"
+            },
+            "timelapse_push": {
+                "name": "Időzített felvétel értesítés"
+            },
+            "sound_push": {
+                "name": "Hang értesítés"
+            },
+            "device_offline_push": {
+                "name": "Eszköz offline értesítés"
+            },
+            "motion_recording": {
+                "name": "Mozgásrögzítés"
+            },
+            "timelapse": {
+                "name": "Időzített felvétel"
+            },
+            "sound_recording": {
+                "name": "Hangrögzítés"
+            },
+            "camera": {
+                "name": "Kamera"
+            },
+            "high_temp_alarm": {
+                "name": "Magas hőmérséklet riasztás"
+            },
+            "face_recognition_push": {
+                "name": "Arcfelismerés értesítés"
+            },
+            "scheduled_sleep": {
+                "name": "Ütemezett alvás"
+            },
+            "anti_tamper_alarm": {
+                "name": "Szabotázs elleni riasztás"
+            },
+            "face_recording": {
+                "name": "Arcrögzítés"
+            },
+            "doorbell_notification": {
+                "name": "Csengő értesítés"
+            },
+            "low_temp_alarm": {
+                "name": "Alacsony hőmérséklet riasztás"
+            },
+            "doorbell_recording": {
+                "name": "Csengő rögzítés"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Hangerő"
+            },
+            "system_volume": {
+                "name": "Rendszerhangerő"
+            },
+            "alarm_volume": {
+                "name": "Riasztás hangereje"
+            },
+            "doorbell_volume": {
+                "name": "Csengő hangereje"
+            },
+            "alarm_duration": {
+                "name": "Riasztás időtartama"
+            },
+            "doorbell_duration": {
+                "name": "Csengő időtartama"
+            },
+            "music_volume": {
+                "name": "Zene hangereje"
+            },
+            "alarm_clock_volume": {
+                "name": "Ébresztő hangereje"
+            },
+            "night_light_brightness": {
+                "name": "Éjszakai fény fényereje"
+            },
+            "arming_delay_time": {
+                "name": "Élesítési késleltetés"
+            },
+            "camera_volume": {
+                "name": "Kamera hangereje"
+            },
+            "face_recognition_interval": {
+                "name": "Arcfelismerési időköz"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Átjáró nyelve",
+                "state": {
+                    "chinese": "Kínai",
+                    "english": "Angol"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Riasztás csengőhangja",
+                "state": {
+                    "default": "Alapértelmezett",
+                    "police_car_1": "Rendőrautó hang 1",
+                    "police_car_2": "Rendőrautó hang 2",
+                    "safety_accident": "Biztonsági baleset hang",
+                    "missile_countdown": "Rakéta visszaszámlálás",
+                    "ghost_scream": "Szellemsikoly",
+                    "sniper_rifle": "Mesterlövész puska",
+                    "battle": "Csata hang",
+                    "air_raid_alarm": "Légiriadó",
+                    "dog_barking": "Kutyaugatás"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Csengőhang",
+                "state": {
+                    "default": "Alapértelmezett",
+                    "index_0": "0. index",
+                    "index_1": "1. index",
+                    "index_2": "2. index",
+                    "index_3": "3. index",
+                    "index_4": "4. index",
+                    "index_5": "5. index",
+                    "index_6": "6. index",
+                    "index_7": "7. index",
+                    "index_8": "8. index"
+                }
+            },
+            "screen_flip": {
+                "name": "Képernyő tükrözése",
+                "state": {
+                    "normal": "Normál",
+                    "flip_horizontally": "Vízszintes tükrözés",
+                    "flip_vertically": "Függőleges tükrözés",
+                    "flip_horizontally_and_vertically": "Vízszintes és függőleges tükrözés"
+                }
+            },
+            "camera_mode": {
+                "name": "Kamera mód",
+                "state": {
+                    "off": "Ki",
+                    "on": "Be",
+                    "always_on": "Mindig be"
+                }
+            },
+            "work_mode": {
+                "name": "Munkamód",
+                "state": {
+                    "radar_infrared": "Radar + Infravörös",
+                    "radar_only": "Csak radar",
+                    "infrared_only": "Csak infravörös"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Fel"
+            },
+            "ptz_down": {
+                "name": "Le"
+            },
+            "ptz_left": {
+                "name": "Balra"
+            },
+            "ptz_right": {
+                "name": "Jobbra"
+            },
+            "ring_alarm_bell": {
+                "name": "Riasztócsengő megszólaltatása"
+            },
+            "restart_device": {
+                "name": "Eszköz újraindítása"
+            },
+            "restart_coordinator": {
+                "name": "Koordinátor újraindítása"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/it.json
+++ b/custom_components/ha_aqara_devices/translations/it.json
@@ -32,18 +32,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Visione notturna" },
-            "gesture_v_sign": { "name": "Gesto segno V" },
-            "gesture_four": { "name": "Gesto quattro" },
-            "gesture_high_five": { "name": "Gesto cinque" },
-            "gesture_finger_gun": { "name": "Gesto pistola con le dita" },
-            "gesture_ok": { "name": "Gesto OK" },
-            "gesture_v_sign_both_hands": { "name": "Gesto segno V con entrambe le mani" },
-            "gesture_four_both_hands": { "name": "Gesto quattro con entrambe le mani" },
-            "gesture_high_five_both_hands": { "name": "Gesto cinque con entrambe le mani" },
-            "gesture_finger_gun_both_hands": { "name": "Gesto pistola con entrambe le mani" },
-            "gesture_ok_both_hands": { "name": "Gesto OK con entrambe le mani" },
-            "motion_event": { "name": "Evento di movimento" }
+            "night_vision": {
+                "name": "Visione notturna"
+            },
+            "motion_event": {
+                "name": "Evento di movimento"
+            },
+            "gesture_v_sign": {
+                "name": "Gesto segno V"
+            },
+            "gesture_four": {
+                "name": "Gesto Quattro"
+            },
+            "gesture_high_five": {
+                "name": "Gesto Batti il cinque"
+            },
+            "gesture_finger_gun": {
+                "name": "Gesto Pistola con le dita"
+            },
+            "gesture_ok": {
+                "name": "Gesto OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Gesto segno V entrambe le mani"
+            },
+            "gesture_four_both_hands": {
+                "name": "Gesto Quattro entrambe le mani"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Gesto Batti il cinque entrambe le mani"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Gesto Pistola con le dita entrambe le mani"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Gesto OK entrambe le mani"
+            },
+            "doorbell_ring": {
+                "name": "Campanello"
+            },
+            "detection_area": {
+                "name": "Area di rilevamento {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Fuso orario del gateway"
+            },
+            "night_light_configuration": {
+                "name": "Configurazione luce notturna"
+            },
+            "face_recognition_event": {
+                "name": "Evento di riconoscimento facciale"
+            },
+            "stranger_face_event": {
+                "name": "Evento volto sconosciuto"
+            },
+            "door_event": {
+                "name": "Evento porta",
+                "state": {
+                    "door_opened": "Porta aperta",
+                    "door_closed": "Porta chiusa",
+                    "timeout_without_closing": "Timeout senza chiusura",
+                    "knock_on_the_door": "Bussata alla porta",
+                    "attempted_break_in": "Tentativo di effrazione",
+                    "door_ajar": "Porta socchiusa"
+                }
+            },
+            "lock_state": {
+                "name": "Stato serratura",
+                "state": {
+                    "door_cannot_be_closed": "La porta non può essere chiusa",
+                    "door_is_open": "La porta è aperta",
+                    "door_closed_handle_not_lifted": "Porta chiusa ma maniglia non sollevata",
+                    "door_is_locked": "La porta è bloccata",
+                    "door_is_locked_by_night_latch_knob": "Porta bloccata dal pomello notturno",
+                    "door_is_unlocked": "La porta è sbloccata",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Porta bloccata da maniglia frontale e pomello notturno",
+                    "door_is_almost_closed": "La porta è quasi chiusa"
+                }
+            },
+            "open_door_method": {
+                "name": "Metodo di apertura",
+                "state": {
+                    "fingerprint_unlock": "Sblocco con impronta",
+                    "permanent_password_unlock": "Sblocco con password permanente",
+                    "nfc_unlock": "Sblocco NFC",
+                    "bluetooth_unlock": "Sblocco Bluetooth",
+                    "temporary_password_unlock": "Sblocco con password temporanea",
+                    "mechanical_key_unlock": "Sblocco con chiave meccanica",
+                    "dual_authentication_unlock": "Sblocco con doppia autenticazione",
+                    "duress_fingerprint_unlock": "Sblocco con impronta di emergenza",
+                    "homekit_unlock": "Sblocco HomeKit",
+                    "face_unlock": "Sblocco con volto",
+                    "aiot_remote_unlock": "Sblocco remoto AIoT",
+                    "google_password_unlock": "Sblocco con password Google",
+                    "outdoor_unlock": "Sblocco esterno"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "ID utente impronta"
+            },
+            "user_id_password": {
+                "name": "ID utente password"
+            },
+            "user_id_nfc": {
+                "name": "ID utente NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "ID utente Bluetooth HomeKit"
+            },
+            "user_id_temporary_password": {
+                "name": "ID utente password temporanea"
+            },
+            "people_counting": {
+                "name": "Conteggio persone"
+            },
+            "people_counting_per_minute": {
+                "name": "Conteggio persone (al minuto)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Conteggio persone intera area (10 s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Conteggio persone zona {index} (10 s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Conteggio persone zona {index} (al minuto)"
+            },
+            "heart_rate": {
+                "name": "Frequenza cardiaca"
+            },
+            "respiration_rate": {
+                "name": "Frequenza respiratoria"
+            },
+            "body_movement": {
+                "name": "Movimento corporeo"
+            },
+            "sleep_state": {
+                "name": "Stato del sonno"
+            },
+            "operating_mode": {
+                "name": "Modalità di funzionamento",
+                "state": {
+                    "zone_detection": "Rilevamento zona",
+                    "fall_detection": "Rilevamento cadute",
+                    "sleep_monitoring": "Monitoraggio del sonno"
+                }
+            },
+            "view_zoom": {
+                "name": "Zoom vista",
+                "state": {
+                    "full": "Completo",
+                    "adaptive": "Adattivo"
+                }
+            },
+            "mounting_position": {
+                "name": "Posizione di montaggio",
+                "state": {
+                    "wall": "Parete",
+                    "left_corner": "Angolo sinistro",
+                    "right_corner": "Angolo destro"
+                }
+            },
+            "installation_angle": {
+                "name": "Angolo di installazione",
+                "state": {
+                    "face_up": "Verso l'alto",
+                    "oblique": "Obliquo",
+                    "horizontal": "Orizzontale",
+                    "face_down": "Verso il basso"
+                }
+            },
+            "attitude_status": {
+                "name": "Stato di orientamento"
+            },
+            "presence_sensitivity": {
+                "name": "Sensibilità di presenza",
+                "state": {
+                    "low": "Basso",
+                    "medium": "Medio",
+                    "high": "Alto"
+                }
+            },
+            "proximity_distance": {
+                "name": "Distanza di prossimità",
+                "state": {
+                    "far": "Lontano",
+                    "medium": "Medio",
+                    "close": "Vicino"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Sensibilità rilevamento cadute",
+                "state": {
+                    "low": "Basso",
+                    "medium": "Medio",
+                    "high": "Alto"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Inverti direzione coordinate",
+                "state": {
+                    "disable": "Disabilitato",
+                    "enable": "Abilitato",
+                    "auto": "Automatico"
+                }
+            },
+            "detection_direction": {
+                "name": "Direzione di rilevamento",
+                "state": {
+                    "default": "Predefinito",
+                    "left_right": "Sinistra/Destra"
+                }
+            },
+            "ai_person_detection": {
+                "name": "Rilevamento persone IA",
+                "state": {
+                    "disable": "Disabilitato",
+                    "enable": "Abilitato"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Modalità anti-inquinamento luminoso",
+                "state": {
+                    "disable": "Disabilitato",
+                    "enable": "Abilitato"
+                }
+            },
+            "activity_status": {
+                "name": "Stato attività",
+                "state": {
+                    "unoccupied": "Non occupato",
+                    "moving": "In movimento",
+                    "stationary": "Fermo"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Video"
+            },
+            "detect_human": {
+                "name": "Rileva umano"
+            },
+            "detect_pet": {
+                "name": "Rileva animale"
+            },
+            "detect_gesture": {
+                "name": "Rileva gesto"
+            },
+            "detect_face": {
+                "name": "Rileva volto"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Protezione eliminazione sotto-dispositivi"
+            },
+            "sound_detection": {
+                "name": "Rilevamento suono"
+            },
+            "timed_sleep": {
+                "name": "Sospensione programmata"
+            },
+            "motion_push": {
+                "name": "Notifica movimento"
+            },
+            "motion_detection": {
+                "name": "Rilevamento movimento"
+            },
+            "indicator_light": {
+                "name": "Spia luminosa"
+            },
+            "timelapse_push": {
+                "name": "Notifica timelapse"
+            },
+            "sound_push": {
+                "name": "Notifica suono"
+            },
+            "device_offline_push": {
+                "name": "Notifica dispositivo offline"
+            },
+            "motion_recording": {
+                "name": "Registrazione movimento"
+            },
+            "timelapse": {
+                "name": "Timelapse"
+            },
+            "sound_recording": {
+                "name": "Registrazione audio"
+            },
+            "camera": {
+                "name": "Telecamera"
+            },
+            "high_temp_alarm": {
+                "name": "Allarme alta temperatura"
+            },
+            "face_recognition_push": {
+                "name": "Notifica riconoscimento facciale"
+            },
+            "scheduled_sleep": {
+                "name": "Sospensione pianificata"
+            },
+            "anti_tamper_alarm": {
+                "name": "Allarme antimanomissione"
+            },
+            "face_recording": {
+                "name": "Registrazione volto"
+            },
+            "doorbell_notification": {
+                "name": "Notifica campanello"
+            },
+            "low_temp_alarm": {
+                "name": "Allarme bassa temperatura"
+            },
+            "doorbell_recording": {
+                "name": "Registrazione campanello"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Volume"
+            },
+            "system_volume": {
+                "name": "Volume di sistema"
+            },
+            "alarm_volume": {
+                "name": "Volume allarme"
+            },
+            "doorbell_volume": {
+                "name": "Volume campanello"
+            },
+            "alarm_duration": {
+                "name": "Durata allarme"
+            },
+            "doorbell_duration": {
+                "name": "Durata campanello"
+            },
+            "music_volume": {
+                "name": "Volume musica"
+            },
+            "alarm_clock_volume": {
+                "name": "Volume sveglia"
+            },
+            "night_light_brightness": {
+                "name": "Luminosità luce notturna"
+            },
+            "arming_delay_time": {
+                "name": "Tempo ritardo inserimento"
+            },
+            "camera_volume": {
+                "name": "Volume telecamera"
+            },
+            "face_recognition_interval": {
+                "name": "Intervallo riconoscimento facciale"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Lingua del gateway",
+                "state": {
+                    "chinese": "Cinese",
+                    "english": "Inglese"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Suoneria allarme",
+                "state": {
+                    "default": "Predefinito",
+                    "police_car_1": "Suono auto polizia 1",
+                    "police_car_2": "Suono auto polizia 2",
+                    "safety_accident": "Suono incidente",
+                    "missile_countdown": "Conto alla rovescia missile",
+                    "ghost_scream": "Urlo di fantasma",
+                    "sniper_rifle": "Fucile da cecchino",
+                    "battle": "Suono di battaglia",
+                    "air_raid_alarm": "Allarme attacco aereo",
+                    "dog_barking": "Cane che abbaia"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Suoneria campanello",
+                "state": {
+                    "default": "Predefinito",
+                    "index_0": "Indice 0",
+                    "index_1": "Indice 1",
+                    "index_2": "Indice 2",
+                    "index_3": "Indice 3",
+                    "index_4": "Indice 4",
+                    "index_5": "Indice 5",
+                    "index_6": "Indice 6",
+                    "index_7": "Indice 7",
+                    "index_8": "Indice 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Capovolgimento schermo",
+                "state": {
+                    "normal": "Normale",
+                    "flip_horizontally": "Capovolgi orizzontalmente",
+                    "flip_vertically": "Capovolgi verticalmente",
+                    "flip_horizontally_and_vertically": "Capovolgi orizzontalmente e verticalmente"
+                }
+            },
+            "camera_mode": {
+                "name": "Modalità telecamera",
+                "state": {
+                    "off": "Spento",
+                    "on": "Acceso",
+                    "always_on": "Sempre acceso"
+                }
+            },
+            "work_mode": {
+                "name": "Modalità di lavoro",
+                "state": {
+                    "radar_infrared": "Radar + Infrarosso",
+                    "radar_only": "Solo radar",
+                    "infrared_only": "Solo infrarosso"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Su"
+            },
+            "ptz_down": {
+                "name": "Giù"
+            },
+            "ptz_left": {
+                "name": "Sinistra"
+            },
+            "ptz_right": {
+                "name": "Destra"
+            },
+            "ring_alarm_bell": {
+                "name": "Suona allarme"
+            },
+            "restart_device": {
+                "name": "Riavvia dispositivo"
+            },
+            "restart_coordinator": {
+                "name": "Riavvia coordinatore"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/nl.json
+++ b/custom_components/ha_aqara_devices/translations/nl.json
@@ -32,18 +32,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Nachtzicht" },
-            "gesture_v_sign": { "name": "Gebaar V-teken" },
-            "gesture_four": { "name": "Gebaar vier" },
-            "gesture_high_five": { "name": "Gebaar high five" },
-            "gesture_finger_gun": { "name": "Gebaar vingerpistool" },
-            "gesture_ok": { "name": "Gebaar OK" },
-            "gesture_v_sign_both_hands": { "name": "Gebaar V-teken met beide handen" },
-            "gesture_four_both_hands": { "name": "Gebaar vier met beide handen" },
-            "gesture_high_five_both_hands": { "name": "Gebaar high five met beide handen" },
-            "gesture_finger_gun_both_hands": { "name": "Gebaar vingerpistool met beide handen" },
-            "gesture_ok_both_hands": { "name": "Gebaar OK met beide handen" },
-            "motion_event": { "name": "Bewegingsgebeurtenis" }
+            "night_vision": {
+                "name": "Nachtzicht"
+            },
+            "motion_event": {
+                "name": "Bewegingsgebeurtenis"
+            },
+            "gesture_v_sign": {
+                "name": "Gebaar V-teken"
+            },
+            "gesture_four": {
+                "name": "Gebaar Vier"
+            },
+            "gesture_high_five": {
+                "name": "Gebaar High Five"
+            },
+            "gesture_finger_gun": {
+                "name": "Gebaar Vingerpistool"
+            },
+            "gesture_ok": {
+                "name": "Gebaar OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Gebaar V-teken beide handen"
+            },
+            "gesture_four_both_hands": {
+                "name": "Gebaar Vier beide handen"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Gebaar High Five beide handen"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Gebaar Vingerpistool beide handen"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Gebaar OK beide handen"
+            },
+            "doorbell_ring": {
+                "name": "Deurbel"
+            },
+            "detection_area": {
+                "name": "Detectiezone {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Tijdzone gateway"
+            },
+            "night_light_configuration": {
+                "name": "Configuratie nachtlamp"
+            },
+            "face_recognition_event": {
+                "name": "Gezichtsherkenningsgebeurtenis"
+            },
+            "stranger_face_event": {
+                "name": "Onbekend gezicht-gebeurtenis"
+            },
+            "door_event": {
+                "name": "Deurgebeurtenis",
+                "state": {
+                    "door_opened": "Deur geopend",
+                    "door_closed": "Deur gesloten",
+                    "timeout_without_closing": "Time-out zonder sluiten",
+                    "knock_on_the_door": "Klop op de deur",
+                    "attempted_break_in": "Inbraakpoging",
+                    "door_ajar": "Deur op een kier"
+                }
+            },
+            "lock_state": {
+                "name": "Status deurslot",
+                "state": {
+                    "door_cannot_be_closed": "Deur kan niet worden gesloten",
+                    "door_is_open": "Deur is open",
+                    "door_closed_handle_not_lifted": "Deur gesloten maar klink niet omhoog",
+                    "door_is_locked": "Deur is vergrendeld",
+                    "door_is_locked_by_night_latch_knob": "Deur vergrendeld met nachtknop",
+                    "door_is_unlocked": "Deur is ontgrendeld",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Deur vergrendeld met voorklink en nachtknop",
+                    "door_is_almost_closed": "Deur is bijna gesloten"
+                }
+            },
+            "open_door_method": {
+                "name": "Methode deur openen",
+                "state": {
+                    "fingerprint_unlock": "Ontgrendelen met vingerafdruk",
+                    "permanent_password_unlock": "Ontgrendelen met permanent wachtwoord",
+                    "nfc_unlock": "Ontgrendelen met NFC",
+                    "bluetooth_unlock": "Ontgrendelen met Bluetooth",
+                    "temporary_password_unlock": "Ontgrendelen met tijdelijk wachtwoord",
+                    "mechanical_key_unlock": "Ontgrendelen met mechanische sleutel",
+                    "dual_authentication_unlock": "Ontgrendelen met dubbele authenticatie",
+                    "duress_fingerprint_unlock": "Ontgrendelen met noodvingerafdruk",
+                    "homekit_unlock": "Ontgrendelen met HomeKit",
+                    "face_unlock": "Ontgrendelen met gezicht",
+                    "aiot_remote_unlock": "AIoT-ontgrendeling op afstand",
+                    "google_password_unlock": "Ontgrendelen met Google-wachtwoord",
+                    "outdoor_unlock": "Ontgrendelen buiten"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "Gebruikers-ID vingerafdruk"
+            },
+            "user_id_password": {
+                "name": "Gebruikers-ID wachtwoord"
+            },
+            "user_id_nfc": {
+                "name": "Gebruikers-ID NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "Gebruikers-ID HomeKit Bluetooth"
+            },
+            "user_id_temporary_password": {
+                "name": "Gebruikers-ID tijdelijk wachtwoord"
+            },
+            "people_counting": {
+                "name": "Personen tellen"
+            },
+            "people_counting_per_minute": {
+                "name": "Personen tellen (per minuut)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Personentelling hele gebied (10 s)"
+            },
+            "zone_people_count_10s": {
+                "name": "Personentelling zone {index} (10 s)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Personentelling zone {index} (per minuut)"
+            },
+            "heart_rate": {
+                "name": "Hartslag"
+            },
+            "respiration_rate": {
+                "name": "Ademhalingsfrequentie"
+            },
+            "body_movement": {
+                "name": "Lichaamsbeweging"
+            },
+            "sleep_state": {
+                "name": "Slaaptoestand"
+            },
+            "operating_mode": {
+                "name": "Bedrijfsmodus",
+                "state": {
+                    "zone_detection": "Zonedetectie",
+                    "fall_detection": "Valdetectie",
+                    "sleep_monitoring": "Slaapmonitoring"
+                }
+            },
+            "view_zoom": {
+                "name": "Weergavezoom",
+                "state": {
+                    "full": "Volledig",
+                    "adaptive": "Adaptief"
+                }
+            },
+            "mounting_position": {
+                "name": "Montagepositie",
+                "state": {
+                    "wall": "Muur",
+                    "left_corner": "Linkerhoek",
+                    "right_corner": "Rechterhoek"
+                }
+            },
+            "installation_angle": {
+                "name": "Installatiehoek",
+                "state": {
+                    "face_up": "Naar boven",
+                    "oblique": "Schuin",
+                    "horizontal": "Horizontaal",
+                    "face_down": "Naar beneden"
+                }
+            },
+            "attitude_status": {
+                "name": "Oriëntatiestatus"
+            },
+            "presence_sensitivity": {
+                "name": "Aanwezigheidsgevoeligheid",
+                "state": {
+                    "low": "Laag",
+                    "medium": "Gemiddeld",
+                    "high": "Hoog"
+                }
+            },
+            "proximity_distance": {
+                "name": "Nabijheidsafstand",
+                "state": {
+                    "far": "Ver",
+                    "medium": "Gemiddeld",
+                    "close": "Dichtbij"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Gevoeligheid valdetectie",
+                "state": {
+                    "low": "Laag",
+                    "medium": "Gemiddeld",
+                    "high": "Hoog"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Coördinaatrichting omkeren",
+                "state": {
+                    "disable": "Uitgeschakeld",
+                    "enable": "Ingeschakeld",
+                    "auto": "Automatisch"
+                }
+            },
+            "detection_direction": {
+                "name": "Detectierichting",
+                "state": {
+                    "default": "Standaard",
+                    "left_right": "Links/Rechts"
+                }
+            },
+            "ai_person_detection": {
+                "name": "AI-persoonsdetectie",
+                "state": {
+                    "disable": "Uitgeschakeld",
+                    "enable": "Ingeschakeld"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Anti-lichtvervuilingsmodus",
+                "state": {
+                    "disable": "Uitgeschakeld",
+                    "enable": "Ingeschakeld"
+                }
+            },
+            "activity_status": {
+                "name": "Activiteitsstatus",
+                "state": {
+                    "unoccupied": "Onbezet",
+                    "moving": "In beweging",
+                    "stationary": "Stilstaand"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Video"
+            },
+            "detect_human": {
+                "name": "Mens detecteren"
+            },
+            "detect_pet": {
+                "name": "Huisdier detecteren"
+            },
+            "detect_gesture": {
+                "name": "Gebaar detecteren"
+            },
+            "detect_face": {
+                "name": "Gezicht detecteren"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Verwijderingsbeveiliging subapparaat"
+            },
+            "sound_detection": {
+                "name": "Geluidsdetectie"
+            },
+            "timed_sleep": {
+                "name": "Getimede slaapstand"
+            },
+            "motion_push": {
+                "name": "Bewegingsmelding"
+            },
+            "motion_detection": {
+                "name": "Bewegingsdetectie"
+            },
+            "indicator_light": {
+                "name": "Indicatielampje"
+            },
+            "timelapse_push": {
+                "name": "Timelapse-melding"
+            },
+            "sound_push": {
+                "name": "Geluidsmelding"
+            },
+            "device_offline_push": {
+                "name": "Apparaat-offline-melding"
+            },
+            "motion_recording": {
+                "name": "Bewegingsopname"
+            },
+            "timelapse": {
+                "name": "Timelapse"
+            },
+            "sound_recording": {
+                "name": "Geluidsopname"
+            },
+            "camera": {
+                "name": "Camera"
+            },
+            "high_temp_alarm": {
+                "name": "Alarm hoge temperatuur"
+            },
+            "face_recognition_push": {
+                "name": "Gezichtsherkenningsmelding"
+            },
+            "scheduled_sleep": {
+                "name": "Geplande slaapstand"
+            },
+            "anti_tamper_alarm": {
+                "name": "Sabotagealarm"
+            },
+            "face_recording": {
+                "name": "Gezichtsopname"
+            },
+            "doorbell_notification": {
+                "name": "Deurbelmelding"
+            },
+            "low_temp_alarm": {
+                "name": "Alarm lage temperatuur"
+            },
+            "doorbell_recording": {
+                "name": "Deurbelopname"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Volume"
+            },
+            "system_volume": {
+                "name": "Systeemvolume"
+            },
+            "alarm_volume": {
+                "name": "Alarmvolume"
+            },
+            "doorbell_volume": {
+                "name": "Deurbelvolume"
+            },
+            "alarm_duration": {
+                "name": "Alarmduur"
+            },
+            "doorbell_duration": {
+                "name": "Deurbelduur"
+            },
+            "music_volume": {
+                "name": "Muziekvolume"
+            },
+            "alarm_clock_volume": {
+                "name": "Wekkervolume"
+            },
+            "night_light_brightness": {
+                "name": "Helderheid nachtlamp"
+            },
+            "arming_delay_time": {
+                "name": "Inschakelvertraging"
+            },
+            "camera_volume": {
+                "name": "Cameravolume"
+            },
+            "face_recognition_interval": {
+                "name": "Interval gezichtsherkenning"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Taal gateway",
+                "state": {
+                    "chinese": "Chinees",
+                    "english": "Engels"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Alarmtoon",
+                "state": {
+                    "default": "Standaard",
+                    "police_car_1": "Politieautogeluid 1",
+                    "police_car_2": "Politieautogeluid 2",
+                    "safety_accident": "Veiligheidsongevalgeluid",
+                    "missile_countdown": "Raketaftelling",
+                    "ghost_scream": "Spookgeschreeuw",
+                    "sniper_rifle": "Sluipschuttersgeweer",
+                    "battle": "Gevechtsgeluid",
+                    "air_raid_alarm": "Luchtalarm",
+                    "dog_barking": "Hondengeblaf"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Deurbeltoon",
+                "state": {
+                    "default": "Standaard",
+                    "index_0": "Index 0",
+                    "index_1": "Index 1",
+                    "index_2": "Index 2",
+                    "index_3": "Index 3",
+                    "index_4": "Index 4",
+                    "index_5": "Index 5",
+                    "index_6": "Index 6",
+                    "index_7": "Index 7",
+                    "index_8": "Index 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Scherm spiegelen",
+                "state": {
+                    "normal": "Normaal",
+                    "flip_horizontally": "Horizontaal spiegelen",
+                    "flip_vertically": "Verticaal spiegelen",
+                    "flip_horizontally_and_vertically": "Horizontaal en verticaal spiegelen"
+                }
+            },
+            "camera_mode": {
+                "name": "Cameramodus",
+                "state": {
+                    "off": "Uit",
+                    "on": "Aan",
+                    "always_on": "Altijd aan"
+                }
+            },
+            "work_mode": {
+                "name": "Werkmodus",
+                "state": {
+                    "radar_infrared": "Radar + Infrarood",
+                    "radar_only": "Alleen radar",
+                    "infrared_only": "Alleen infrarood"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Omhoog"
+            },
+            "ptz_down": {
+                "name": "Omlaag"
+            },
+            "ptz_left": {
+                "name": "Links"
+            },
+            "ptz_right": {
+                "name": "Rechts"
+            },
+            "ring_alarm_bell": {
+                "name": "Alarmbel laten rinkelen"
+            },
+            "restart_device": {
+                "name": "Apparaat herstarten"
+            },
+            "restart_coordinator": {
+                "name": "Coördinator herstarten"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/ru.json
+++ b/custom_components/ha_aqara_devices/translations/ru.json
@@ -32,18 +32,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "Ночное видение" },
-            "gesture_v_sign": { "name": "Жест: V (мир)" },
-            "gesture_four": { "name": "Жест: Четыре" },
-            "gesture_high_five": { "name": "Жест: Дай пять" },
-            "gesture_finger_gun": { "name": "Жест: Пистолет" },
-            "gesture_ok": { "name": "Жест: OK" },
-            "gesture_v_sign_both_hands": { "name": "Жест: V двумя руками" },
-            "gesture_four_both_hands": { "name": "Жест: Четыре двумя руками" },
-            "gesture_high_five_both_hands": { "name": "Жест: Дай пять двумя руками" },
-            "gesture_finger_gun_both_hands": { "name": "Жест: Пистолет двумя руками" },
-            "gesture_ok_both_hands": { "name": "Жест: OK двумя руками" },
-            "motion_event": { "name": "Событие движения" }
+            "night_vision": {
+                "name": "Ночное видение"
+            },
+            "motion_event": {
+                "name": "Событие движения"
+            },
+            "gesture_v_sign": {
+                "name": "Жест «знак V»"
+            },
+            "gesture_four": {
+                "name": "Жест «четыре»"
+            },
+            "gesture_high_five": {
+                "name": "Жест «дай пять»"
+            },
+            "gesture_finger_gun": {
+                "name": "Жест «пистолет из пальцев»"
+            },
+            "gesture_ok": {
+                "name": "Жест «ОК»"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "Жест «знак V» двумя руками"
+            },
+            "gesture_four_both_hands": {
+                "name": "Жест «четыре» двумя руками"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "Жест «дай пять» двумя руками"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "Жест «пистолет из пальцев» двумя руками"
+            },
+            "gesture_ok_both_hands": {
+                "name": "Жест «ОК» двумя руками"
+            },
+            "doorbell_ring": {
+                "name": "Звонок в дверь"
+            },
+            "detection_area": {
+                "name": "Зона обнаружения {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "Часовой пояс шлюза"
+            },
+            "night_light_configuration": {
+                "name": "Конфигурация ночника"
+            },
+            "face_recognition_event": {
+                "name": "Событие распознавания лица"
+            },
+            "stranger_face_event": {
+                "name": "Событие незнакомого лица"
+            },
+            "door_event": {
+                "name": "Событие двери",
+                "state": {
+                    "door_opened": "Дверь открыта",
+                    "door_closed": "Дверь закрыта",
+                    "timeout_without_closing": "Тайм-аут без закрытия",
+                    "knock_on_the_door": "Стук в дверь",
+                    "attempted_break_in": "Попытка взлома",
+                    "door_ajar": "Дверь приоткрыта"
+                }
+            },
+            "lock_state": {
+                "name": "Состояние замка",
+                "state": {
+                    "door_cannot_be_closed": "Дверь не может быть закрыта",
+                    "door_is_open": "Дверь открыта",
+                    "door_closed_handle_not_lifted": "Дверь закрыта, но ручка не поднята",
+                    "door_is_locked": "Дверь заперта",
+                    "door_is_locked_by_night_latch_knob": "Дверь заперта ночной защёлкой",
+                    "door_is_unlocked": "Дверь отперта",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "Дверь заперта передней ручкой и ночной защёлкой",
+                    "door_is_almost_closed": "Дверь почти закрыта"
+                }
+            },
+            "open_door_method": {
+                "name": "Способ открытия двери",
+                "state": {
+                    "fingerprint_unlock": "Разблокировка отпечатком",
+                    "permanent_password_unlock": "Разблокировка постоянным паролем",
+                    "nfc_unlock": "Разблокировка NFC",
+                    "bluetooth_unlock": "Разблокировка Bluetooth",
+                    "temporary_password_unlock": "Разблокировка временным паролем",
+                    "mechanical_key_unlock": "Разблокировка механическим ключом",
+                    "dual_authentication_unlock": "Разблокировка двойной аутентификацией",
+                    "duress_fingerprint_unlock": "Разблокировка отпечатком под принуждением",
+                    "homekit_unlock": "Разблокировка HomeKit",
+                    "face_unlock": "Разблокировка по лицу",
+                    "aiot_remote_unlock": "Удалённая разблокировка AIoT",
+                    "google_password_unlock": "Разблокировка паролем Google",
+                    "outdoor_unlock": "Разблокировка снаружи"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "ID пользователя отпечатка"
+            },
+            "user_id_password": {
+                "name": "ID пользователя пароля"
+            },
+            "user_id_nfc": {
+                "name": "ID пользователя NFC"
+            },
+            "user_id_ble_homekit": {
+                "name": "ID пользователя Bluetooth HomeKit"
+            },
+            "user_id_temporary_password": {
+                "name": "ID пользователя временного пароля"
+            },
+            "people_counting": {
+                "name": "Подсчёт людей"
+            },
+            "people_counting_per_minute": {
+                "name": "Подсчёт людей (в минуту)"
+            },
+            "whole_area_people_count_10s": {
+                "name": "Подсчёт людей по всей зоне (10 с)"
+            },
+            "zone_people_count_10s": {
+                "name": "Подсчёт людей зоны {index} (10 с)"
+            },
+            "zone_people_count_per_minute": {
+                "name": "Подсчёт людей зоны {index} (в минуту)"
+            },
+            "heart_rate": {
+                "name": "Частота сердечных сокращений"
+            },
+            "respiration_rate": {
+                "name": "Частота дыхания"
+            },
+            "body_movement": {
+                "name": "Движение тела"
+            },
+            "sleep_state": {
+                "name": "Состояние сна"
+            },
+            "operating_mode": {
+                "name": "Режим работы",
+                "state": {
+                    "zone_detection": "Обнаружение зоны",
+                    "fall_detection": "Обнаружение падения",
+                    "sleep_monitoring": "Мониторинг сна"
+                }
+            },
+            "view_zoom": {
+                "name": "Масштаб обзора",
+                "state": {
+                    "full": "Полный",
+                    "adaptive": "Адаптивный"
+                }
+            },
+            "mounting_position": {
+                "name": "Положение монтажа",
+                "state": {
+                    "wall": "Стена",
+                    "left_corner": "Левый угол",
+                    "right_corner": "Правый угол"
+                }
+            },
+            "installation_angle": {
+                "name": "Угол установки",
+                "state": {
+                    "face_up": "Вверх",
+                    "oblique": "Наклонно",
+                    "horizontal": "Горизонтально",
+                    "face_down": "Вниз"
+                }
+            },
+            "attitude_status": {
+                "name": "Состояние положения"
+            },
+            "presence_sensitivity": {
+                "name": "Чувствительность присутствия",
+                "state": {
+                    "low": "Низкая",
+                    "medium": "Средняя",
+                    "high": "Высокая"
+                }
+            },
+            "proximity_distance": {
+                "name": "Дистанция приближения",
+                "state": {
+                    "far": "Далеко",
+                    "medium": "Среднее",
+                    "close": "Близко"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "Чувствительность обнаружения падения",
+                "state": {
+                    "low": "Низкая",
+                    "medium": "Средняя",
+                    "high": "Высокая"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "Обратное направление координат",
+                "state": {
+                    "disable": "Отключено",
+                    "enable": "Включено",
+                    "auto": "Авто"
+                }
+            },
+            "detection_direction": {
+                "name": "Направление обнаружения",
+                "state": {
+                    "default": "По умолчанию",
+                    "left_right": "Лево/Право"
+                }
+            },
+            "ai_person_detection": {
+                "name": "ИИ-обнаружение человека",
+                "state": {
+                    "disable": "Отключено",
+                    "enable": "Включено"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "Режим защиты от светового загрязнения",
+                "state": {
+                    "disable": "Отключено",
+                    "enable": "Включено"
+                }
+            },
+            "activity_status": {
+                "name": "Состояние активности",
+                "state": {
+                    "unoccupied": "Не занято",
+                    "moving": "Движение",
+                    "stationary": "Неподвижно"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "Видео"
+            },
+            "detect_human": {
+                "name": "Обнаружение человека"
+            },
+            "detect_pet": {
+                "name": "Обнаружение питомца"
+            },
+            "detect_gesture": {
+                "name": "Обнаружение жеста"
+            },
+            "detect_face": {
+                "name": "Обнаружение лица"
+            },
+            "sub_device_deletion_protection": {
+                "name": "Защита от удаления подустройств"
+            },
+            "sound_detection": {
+                "name": "Обнаружение звука"
+            },
+            "timed_sleep": {
+                "name": "Сон по таймеру"
+            },
+            "motion_push": {
+                "name": "Push при движении"
+            },
+            "motion_detection": {
+                "name": "Обнаружение движения"
+            },
+            "indicator_light": {
+                "name": "Индикатор"
+            },
+            "timelapse_push": {
+                "name": "Push таймлапса"
+            },
+            "sound_push": {
+                "name": "Push звука"
+            },
+            "device_offline_push": {
+                "name": "Push отключения устройства"
+            },
+            "motion_recording": {
+                "name": "Запись при движении"
+            },
+            "timelapse": {
+                "name": "Таймлапс"
+            },
+            "sound_recording": {
+                "name": "Запись звука"
+            },
+            "camera": {
+                "name": "Камера"
+            },
+            "high_temp_alarm": {
+                "name": "Сигнал высокой температуры"
+            },
+            "face_recognition_push": {
+                "name": "Push распознавания лица"
+            },
+            "scheduled_sleep": {
+                "name": "Сон по расписанию"
+            },
+            "anti_tamper_alarm": {
+                "name": "Сигнал вскрытия"
+            },
+            "face_recording": {
+                "name": "Запись лица"
+            },
+            "doorbell_notification": {
+                "name": "Уведомление о звонке"
+            },
+            "low_temp_alarm": {
+                "name": "Сигнал низкой температуры"
+            },
+            "doorbell_recording": {
+                "name": "Запись звонка"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "Громкость"
+            },
+            "system_volume": {
+                "name": "Системная громкость"
+            },
+            "alarm_volume": {
+                "name": "Громкость сигнала"
+            },
+            "doorbell_volume": {
+                "name": "Громкость звонка"
+            },
+            "alarm_duration": {
+                "name": "Длительность сигнала"
+            },
+            "doorbell_duration": {
+                "name": "Длительность звонка"
+            },
+            "music_volume": {
+                "name": "Громкость музыки"
+            },
+            "alarm_clock_volume": {
+                "name": "Громкость будильника"
+            },
+            "night_light_brightness": {
+                "name": "Яркость ночника"
+            },
+            "arming_delay_time": {
+                "name": "Время задержки постановки на охрану"
+            },
+            "camera_volume": {
+                "name": "Громкость камеры"
+            },
+            "face_recognition_interval": {
+                "name": "Интервал распознавания лица"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "Язык шлюза",
+                "state": {
+                    "chinese": "Китайский",
+                    "english": "Английский"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "Мелодия сигнала",
+                "state": {
+                    "default": "По умолчанию",
+                    "police_car_1": "Звук полицейской машины 1",
+                    "police_car_2": "Звук полицейской машины 2",
+                    "safety_accident": "Звук аварии",
+                    "missile_countdown": "Обратный отсчёт ракеты",
+                    "ghost_scream": "Крик призрака",
+                    "sniper_rifle": "Снайперская винтовка",
+                    "battle": "Звук битвы",
+                    "air_raid_alarm": "Сигнал воздушной тревоги",
+                    "dog_barking": "Лай собаки"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "Мелодия звонка",
+                "state": {
+                    "default": "По умолчанию",
+                    "index_0": "Индекс 0",
+                    "index_1": "Индекс 1",
+                    "index_2": "Индекс 2",
+                    "index_3": "Индекс 3",
+                    "index_4": "Индекс 4",
+                    "index_5": "Индекс 5",
+                    "index_6": "Индекс 6",
+                    "index_7": "Индекс 7",
+                    "index_8": "Индекс 8"
+                }
+            },
+            "screen_flip": {
+                "name": "Переворот экрана",
+                "state": {
+                    "normal": "Обычный",
+                    "flip_horizontally": "Отразить по горизонтали",
+                    "flip_vertically": "Отразить по вертикали",
+                    "flip_horizontally_and_vertically": "Отразить по горизонтали и вертикали"
+                }
+            },
+            "camera_mode": {
+                "name": "Режим камеры",
+                "state": {
+                    "off": "Выкл",
+                    "on": "Вкл",
+                    "always_on": "Всегда включено"
+                }
+            },
+            "work_mode": {
+                "name": "Рабочий режим",
+                "state": {
+                    "radar_infrared": "Радар + Инфракрасный",
+                    "radar_only": "Только радар",
+                    "infrared_only": "Только инфракрасный"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "Вверх"
+            },
+            "ptz_down": {
+                "name": "Вниз"
+            },
+            "ptz_left": {
+                "name": "Влево"
+            },
+            "ptz_right": {
+                "name": "Вправо"
+            },
+            "ring_alarm_bell": {
+                "name": "Включить сигнал тревоги"
+            },
+            "restart_device": {
+                "name": "Перезапустить устройство"
+            },
+            "restart_coordinator": {
+                "name": "Перезапустить координатор"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/zh-Hans.json
+++ b/custom_components/ha_aqara_devices/translations/zh-Hans.json
@@ -59,18 +59,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "夜视" },
-            "gesture_v_sign": { "name": "V 手势" },
-            "gesture_four": { "name": "四指手势" },
-            "gesture_high_five": { "name": "击掌手势" },
-            "gesture_finger_gun": { "name": "手枪手势" },
-            "gesture_ok": { "name": "OK 手势" },
-            "gesture_v_sign_both_hands": { "name": "双手 V 手势" },
-            "gesture_four_both_hands": { "name": "双手四指手势" },
-            "gesture_high_five_both_hands": { "name": "双手击掌手势" },
-            "gesture_finger_gun_both_hands": { "name": "双手手枪手势" },
-            "gesture_ok_both_hands": { "name": "双手 OK 手势" },
-            "motion_event": { "name": "移动事件" }
+            "night_vision": {
+                "name": "夜视"
+            },
+            "motion_event": {
+                "name": "移动事件"
+            },
+            "gesture_v_sign": {
+                "name": "手势 V 字"
+            },
+            "gesture_four": {
+                "name": "手势四"
+            },
+            "gesture_high_five": {
+                "name": "手势击掌"
+            },
+            "gesture_finger_gun": {
+                "name": "手势手枪"
+            },
+            "gesture_ok": {
+                "name": "手势 OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "双手手势 V 字"
+            },
+            "gesture_four_both_hands": {
+                "name": "双手手势四"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "双手手势击掌"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "双手手势手枪"
+            },
+            "gesture_ok_both_hands": {
+                "name": "双手手势 OK"
+            },
+            "doorbell_ring": {
+                "name": "门铃响铃"
+            },
+            "detection_area": {
+                "name": "检测区域 {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "网关时区"
+            },
+            "night_light_configuration": {
+                "name": "夜灯配置"
+            },
+            "face_recognition_event": {
+                "name": "人脸识别事件"
+            },
+            "stranger_face_event": {
+                "name": "陌生人脸事件"
+            },
+            "door_event": {
+                "name": "门事件",
+                "state": {
+                    "door_opened": "门已打开",
+                    "door_closed": "门已关闭",
+                    "timeout_without_closing": "超时未关闭",
+                    "knock_on_the_door": "敲门",
+                    "attempted_break_in": "闯入尝试",
+                    "door_ajar": "门虚掩"
+                }
+            },
+            "lock_state": {
+                "name": "门锁状态",
+                "state": {
+                    "door_cannot_be_closed": "门无法关闭",
+                    "door_is_open": "门已打开",
+                    "door_closed_handle_not_lifted": "门已关闭但门把手未抬起",
+                    "door_is_locked": "门已上锁",
+                    "door_is_locked_by_night_latch_knob": "门已由夜锁旋钮锁定",
+                    "door_is_unlocked": "门已解锁",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "门已由前把手和夜锁旋钮锁定",
+                    "door_is_almost_closed": "门即将关闭"
+                }
+            },
+            "open_door_method": {
+                "name": "开门方式",
+                "state": {
+                    "fingerprint_unlock": "指纹解锁",
+                    "permanent_password_unlock": "永久密码解锁",
+                    "nfc_unlock": "NFC 解锁",
+                    "bluetooth_unlock": "蓝牙解锁",
+                    "temporary_password_unlock": "临时密码解锁",
+                    "mechanical_key_unlock": "机械钥匙解锁",
+                    "dual_authentication_unlock": "双重认证解锁",
+                    "duress_fingerprint_unlock": "胁迫指纹解锁",
+                    "homekit_unlock": "HomeKit 解锁",
+                    "face_unlock": "人脸解锁",
+                    "aiot_remote_unlock": "AIoT 远程解锁",
+                    "google_password_unlock": "Google 密码解锁",
+                    "outdoor_unlock": "室外解锁"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "指纹用户 ID"
+            },
+            "user_id_password": {
+                "name": "密码用户 ID"
+            },
+            "user_id_nfc": {
+                "name": "NFC 用户 ID"
+            },
+            "user_id_ble_homekit": {
+                "name": "HomeKit 蓝牙用户 ID"
+            },
+            "user_id_temporary_password": {
+                "name": "临时密码用户 ID"
+            },
+            "people_counting": {
+                "name": "人数统计"
+            },
+            "people_counting_per_minute": {
+                "name": "人数统计（每分钟）"
+            },
+            "whole_area_people_count_10s": {
+                "name": "整个区域人数（10 秒）"
+            },
+            "zone_people_count_10s": {
+                "name": "区域 {index} 人数（10 秒）"
+            },
+            "zone_people_count_per_minute": {
+                "name": "区域 {index} 人数（每分钟）"
+            },
+            "heart_rate": {
+                "name": "心率"
+            },
+            "respiration_rate": {
+                "name": "呼吸频率"
+            },
+            "body_movement": {
+                "name": "身体活动"
+            },
+            "sleep_state": {
+                "name": "睡眠状态"
+            },
+            "operating_mode": {
+                "name": "工作模式",
+                "state": {
+                    "zone_detection": "区域检测",
+                    "fall_detection": "跌倒检测",
+                    "sleep_monitoring": "睡眠监测"
+                }
+            },
+            "view_zoom": {
+                "name": "视图缩放",
+                "state": {
+                    "full": "全画面",
+                    "adaptive": "自适应"
+                }
+            },
+            "mounting_position": {
+                "name": "安装位置",
+                "state": {
+                    "wall": "墙面",
+                    "left_corner": "左角",
+                    "right_corner": "右角"
+                }
+            },
+            "installation_angle": {
+                "name": "安装角度",
+                "state": {
+                    "face_up": "朝上",
+                    "oblique": "倾斜",
+                    "horizontal": "水平",
+                    "face_down": "朝下"
+                }
+            },
+            "attitude_status": {
+                "name": "姿态状态"
+            },
+            "presence_sensitivity": {
+                "name": "存在灵敏度",
+                "state": {
+                    "low": "低",
+                    "medium": "中",
+                    "high": "高"
+                }
+            },
+            "proximity_distance": {
+                "name": "接近距离",
+                "state": {
+                    "far": "远",
+                    "medium": "中",
+                    "close": "近"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "跌倒检测灵敏度",
+                "state": {
+                    "low": "低",
+                    "medium": "中",
+                    "high": "高"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "反转坐标方向",
+                "state": {
+                    "disable": "禁用",
+                    "enable": "启用",
+                    "auto": "自动"
+                }
+            },
+            "detection_direction": {
+                "name": "检测方向",
+                "state": {
+                    "default": "默认",
+                    "left_right": "左右"
+                }
+            },
+            "ai_person_detection": {
+                "name": "AI 人体检测",
+                "state": {
+                    "disable": "禁用",
+                    "enable": "启用"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "防光污染模式",
+                "state": {
+                    "disable": "禁用",
+                    "enable": "启用"
+                }
+            },
+            "activity_status": {
+                "name": "活动状态",
+                "state": {
+                    "unoccupied": "无人",
+                    "moving": "移动中",
+                    "stationary": "静止"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "视频"
+            },
+            "detect_human": {
+                "name": "检测人类"
+            },
+            "detect_pet": {
+                "name": "检测宠物"
+            },
+            "detect_gesture": {
+                "name": "检测手势"
+            },
+            "detect_face": {
+                "name": "检测人脸"
+            },
+            "sub_device_deletion_protection": {
+                "name": "子设备删除保护"
+            },
+            "sound_detection": {
+                "name": "声音检测"
+            },
+            "timed_sleep": {
+                "name": "定时休眠"
+            },
+            "motion_push": {
+                "name": "移动推送"
+            },
+            "motion_detection": {
+                "name": "移动检测"
+            },
+            "indicator_light": {
+                "name": "指示灯"
+            },
+            "timelapse_push": {
+                "name": "延时推送"
+            },
+            "sound_push": {
+                "name": "声音推送"
+            },
+            "device_offline_push": {
+                "name": "设备离线推送"
+            },
+            "motion_recording": {
+                "name": "移动录制"
+            },
+            "timelapse": {
+                "name": "延时摄影"
+            },
+            "sound_recording": {
+                "name": "声音录制"
+            },
+            "camera": {
+                "name": "摄像头"
+            },
+            "high_temp_alarm": {
+                "name": "高温警报"
+            },
+            "face_recognition_push": {
+                "name": "人脸识别推送"
+            },
+            "scheduled_sleep": {
+                "name": "计划休眠"
+            },
+            "anti_tamper_alarm": {
+                "name": "防拆警报"
+            },
+            "face_recording": {
+                "name": "人脸录制"
+            },
+            "doorbell_notification": {
+                "name": "门铃通知"
+            },
+            "low_temp_alarm": {
+                "name": "低温警报"
+            },
+            "doorbell_recording": {
+                "name": "门铃录制"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "音量"
+            },
+            "system_volume": {
+                "name": "系统音量"
+            },
+            "alarm_volume": {
+                "name": "警报音量"
+            },
+            "doorbell_volume": {
+                "name": "门铃音量"
+            },
+            "alarm_duration": {
+                "name": "警报时长"
+            },
+            "doorbell_duration": {
+                "name": "门铃时长"
+            },
+            "music_volume": {
+                "name": "音乐音量"
+            },
+            "alarm_clock_volume": {
+                "name": "闹钟音量"
+            },
+            "night_light_brightness": {
+                "name": "夜灯亮度"
+            },
+            "arming_delay_time": {
+                "name": "布防延迟时间"
+            },
+            "camera_volume": {
+                "name": "摄像头音量"
+            },
+            "face_recognition_interval": {
+                "name": "人脸识别间隔"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "网关语言",
+                "state": {
+                    "chinese": "中文",
+                    "english": "英文"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "警报铃声",
+                "state": {
+                    "default": "默认",
+                    "police_car_1": "警车声 1",
+                    "police_car_2": "警车声 2",
+                    "safety_accident": "安全事故声",
+                    "missile_countdown": "导弹倒计时",
+                    "ghost_scream": "幽灵尖叫",
+                    "sniper_rifle": "狙击步枪",
+                    "battle": "战斗声",
+                    "air_raid_alarm": "空袭警报",
+                    "dog_barking": "狗叫声"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "门铃铃声",
+                "state": {
+                    "default": "默认",
+                    "index_0": "铃声 0",
+                    "index_1": "铃声 1",
+                    "index_2": "铃声 2",
+                    "index_3": "铃声 3",
+                    "index_4": "铃声 4",
+                    "index_5": "铃声 5",
+                    "index_6": "铃声 6",
+                    "index_7": "铃声 7",
+                    "index_8": "铃声 8"
+                }
+            },
+            "screen_flip": {
+                "name": "屏幕翻转",
+                "state": {
+                    "normal": "正常",
+                    "flip_horizontally": "水平翻转",
+                    "flip_vertically": "垂直翻转",
+                    "flip_horizontally_and_vertically": "水平和垂直翻转"
+                }
+            },
+            "camera_mode": {
+                "name": "摄像头模式",
+                "state": {
+                    "off": "关闭",
+                    "on": "开启",
+                    "always_on": "始终开启"
+                }
+            },
+            "work_mode": {
+                "name": "工作模式",
+                "state": {
+                    "radar_infrared": "雷达 + 红外",
+                    "radar_only": "仅雷达",
+                    "infrared_only": "仅红外"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "向上"
+            },
+            "ptz_down": {
+                "name": "向下"
+            },
+            "ptz_left": {
+                "name": "向左"
+            },
+            "ptz_right": {
+                "name": "向右"
+            },
+            "ring_alarm_bell": {
+                "name": "响铃报警"
+            },
+            "restart_device": {
+                "name": "重启设备"
+            },
+            "restart_coordinator": {
+                "name": "重启协调器"
+            }
         }
     }
 }

--- a/custom_components/ha_aqara_devices/translations/zh-Hant.json
+++ b/custom_components/ha_aqara_devices/translations/zh-Hant.json
@@ -59,18 +59,447 @@
     },
     "entity": {
         "binary_sensor": {
-            "night_vision": { "name": "夜視" },
-            "gesture_v_sign": { "name": "V 手勢" },
-            "gesture_four": { "name": "四指手勢" },
-            "gesture_high_five": { "name": "擊掌手勢" },
-            "gesture_finger_gun": { "name": "手槍手勢" },
-            "gesture_ok": { "name": "OK 手勢" },
-            "gesture_v_sign_both_hands": { "name": "雙手 V 手勢" },
-            "gesture_four_both_hands": { "name": "雙手四指手勢" },
-            "gesture_high_five_both_hands": { "name": "雙手擊掌手勢" },
-            "gesture_finger_gun_both_hands": { "name": "雙手手槍手勢" },
-            "gesture_ok_both_hands": { "name": "雙手 OK 手勢" },
-            "motion_event": { "name": "移動事件" }
+            "night_vision": {
+                "name": "夜視"
+            },
+            "motion_event": {
+                "name": "移動事件"
+            },
+            "gesture_v_sign": {
+                "name": "手勢 V 字"
+            },
+            "gesture_four": {
+                "name": "手勢四"
+            },
+            "gesture_high_five": {
+                "name": "手勢擊掌"
+            },
+            "gesture_finger_gun": {
+                "name": "手勢手槍"
+            },
+            "gesture_ok": {
+                "name": "手勢 OK"
+            },
+            "gesture_v_sign_both_hands": {
+                "name": "雙手手勢 V 字"
+            },
+            "gesture_four_both_hands": {
+                "name": "雙手手勢四"
+            },
+            "gesture_high_five_both_hands": {
+                "name": "雙手手勢擊掌"
+            },
+            "gesture_finger_gun_both_hands": {
+                "name": "雙手手勢手槍"
+            },
+            "gesture_ok_both_hands": {
+                "name": "雙手手勢 OK"
+            },
+            "doorbell_ring": {
+                "name": "門鈴響鈴"
+            },
+            "detection_area": {
+                "name": "偵測區域 {index}"
+            }
+        },
+        "sensor": {
+            "gateway_time_zone": {
+                "name": "閘道時區"
+            },
+            "night_light_configuration": {
+                "name": "夜燈設定"
+            },
+            "face_recognition_event": {
+                "name": "人臉辨識事件"
+            },
+            "stranger_face_event": {
+                "name": "陌生人臉事件"
+            },
+            "door_event": {
+                "name": "門事件",
+                "state": {
+                    "door_opened": "門已開啟",
+                    "door_closed": "門已關閉",
+                    "timeout_without_closing": "逾時未關閉",
+                    "knock_on_the_door": "敲門",
+                    "attempted_break_in": "闖入嘗試",
+                    "door_ajar": "門虛掩"
+                }
+            },
+            "lock_state": {
+                "name": "門鎖狀態",
+                "state": {
+                    "door_cannot_be_closed": "門無法關閉",
+                    "door_is_open": "門已開啟",
+                    "door_closed_handle_not_lifted": "門已關閉但門把手未抬起",
+                    "door_is_locked": "門已上鎖",
+                    "door_is_locked_by_night_latch_knob": "門已由夜鎖旋鈕鎖定",
+                    "door_is_unlocked": "門已解鎖",
+                    "door_is_locked_by_front_handle_and_night_latch_knob": "門已由前把手和夜鎖旋鈕鎖定",
+                    "door_is_almost_closed": "門即將關閉"
+                }
+            },
+            "open_door_method": {
+                "name": "開門方式",
+                "state": {
+                    "fingerprint_unlock": "指紋解鎖",
+                    "permanent_password_unlock": "永久密碼解鎖",
+                    "nfc_unlock": "NFC 解鎖",
+                    "bluetooth_unlock": "藍牙解鎖",
+                    "temporary_password_unlock": "臨時密碼解鎖",
+                    "mechanical_key_unlock": "機械鑰匙解鎖",
+                    "dual_authentication_unlock": "雙重驗證解鎖",
+                    "duress_fingerprint_unlock": "脅迫指紋解鎖",
+                    "homekit_unlock": "HomeKit 解鎖",
+                    "face_unlock": "人臉解鎖",
+                    "aiot_remote_unlock": "AIoT 遠端解鎖",
+                    "google_password_unlock": "Google 密碼解鎖",
+                    "outdoor_unlock": "室外解鎖"
+                }
+            },
+            "user_id_fingerprint": {
+                "name": "指紋使用者 ID"
+            },
+            "user_id_password": {
+                "name": "密碼使用者 ID"
+            },
+            "user_id_nfc": {
+                "name": "NFC 使用者 ID"
+            },
+            "user_id_ble_homekit": {
+                "name": "HomeKit 藍牙使用者 ID"
+            },
+            "user_id_temporary_password": {
+                "name": "臨時密碼使用者 ID"
+            },
+            "people_counting": {
+                "name": "人數統計"
+            },
+            "people_counting_per_minute": {
+                "name": "人數統計（每分鐘）"
+            },
+            "whole_area_people_count_10s": {
+                "name": "整個區域人數（10 秒）"
+            },
+            "zone_people_count_10s": {
+                "name": "區域 {index} 人數（10 秒）"
+            },
+            "zone_people_count_per_minute": {
+                "name": "區域 {index} 人數（每分鐘）"
+            },
+            "heart_rate": {
+                "name": "心率"
+            },
+            "respiration_rate": {
+                "name": "呼吸頻率"
+            },
+            "body_movement": {
+                "name": "身體活動"
+            },
+            "sleep_state": {
+                "name": "睡眠狀態"
+            },
+            "operating_mode": {
+                "name": "工作模式",
+                "state": {
+                    "zone_detection": "區域偵測",
+                    "fall_detection": "跌倒偵測",
+                    "sleep_monitoring": "睡眠監測"
+                }
+            },
+            "view_zoom": {
+                "name": "視圖縮放",
+                "state": {
+                    "full": "全畫面",
+                    "adaptive": "自適應"
+                }
+            },
+            "mounting_position": {
+                "name": "安裝位置",
+                "state": {
+                    "wall": "牆面",
+                    "left_corner": "左角",
+                    "right_corner": "右角"
+                }
+            },
+            "installation_angle": {
+                "name": "安裝角度",
+                "state": {
+                    "face_up": "朝上",
+                    "oblique": "傾斜",
+                    "horizontal": "水平",
+                    "face_down": "朝下"
+                }
+            },
+            "attitude_status": {
+                "name": "姿態狀態"
+            },
+            "presence_sensitivity": {
+                "name": "存在靈敏度",
+                "state": {
+                    "low": "低",
+                    "medium": "中",
+                    "high": "高"
+                }
+            },
+            "proximity_distance": {
+                "name": "接近距離",
+                "state": {
+                    "far": "遠",
+                    "medium": "中",
+                    "close": "近"
+                }
+            },
+            "fall_detection_sensitivity": {
+                "name": "跌倒偵測靈敏度",
+                "state": {
+                    "low": "低",
+                    "medium": "中",
+                    "high": "高"
+                }
+            },
+            "reverse_coordinate_direction": {
+                "name": "反轉座標方向",
+                "state": {
+                    "disable": "停用",
+                    "enable": "啟用",
+                    "auto": "自動"
+                }
+            },
+            "detection_direction": {
+                "name": "偵測方向",
+                "state": {
+                    "default": "預設",
+                    "left_right": "左右"
+                }
+            },
+            "ai_person_detection": {
+                "name": "AI 人體偵測",
+                "state": {
+                    "disable": "停用",
+                    "enable": "啟用"
+                }
+            },
+            "anti_light_pollution_mode": {
+                "name": "防光污染模式",
+                "state": {
+                    "disable": "停用",
+                    "enable": "啟用"
+                }
+            },
+            "activity_status": {
+                "name": "活動狀態",
+                "state": {
+                    "unoccupied": "無人",
+                    "moving": "移動中",
+                    "stationary": "靜止"
+                }
+            }
+        },
+        "switch": {
+            "video": {
+                "name": "視訊"
+            },
+            "detect_human": {
+                "name": "偵測人類"
+            },
+            "detect_pet": {
+                "name": "偵測寵物"
+            },
+            "detect_gesture": {
+                "name": "偵測手勢"
+            },
+            "detect_face": {
+                "name": "偵測人臉"
+            },
+            "sub_device_deletion_protection": {
+                "name": "子裝置刪除保護"
+            },
+            "sound_detection": {
+                "name": "聲音偵測"
+            },
+            "timed_sleep": {
+                "name": "定時休眠"
+            },
+            "motion_push": {
+                "name": "移動推播"
+            },
+            "motion_detection": {
+                "name": "移動偵測"
+            },
+            "indicator_light": {
+                "name": "指示燈"
+            },
+            "timelapse_push": {
+                "name": "縮時推播"
+            },
+            "sound_push": {
+                "name": "聲音推播"
+            },
+            "device_offline_push": {
+                "name": "裝置離線推播"
+            },
+            "motion_recording": {
+                "name": "移動錄影"
+            },
+            "timelapse": {
+                "name": "縮時攝影"
+            },
+            "sound_recording": {
+                "name": "聲音錄製"
+            },
+            "camera": {
+                "name": "攝影機"
+            },
+            "high_temp_alarm": {
+                "name": "高溫警報"
+            },
+            "face_recognition_push": {
+                "name": "人臉辨識推播"
+            },
+            "scheduled_sleep": {
+                "name": "排程休眠"
+            },
+            "anti_tamper_alarm": {
+                "name": "防拆警報"
+            },
+            "face_recording": {
+                "name": "人臉錄製"
+            },
+            "doorbell_notification": {
+                "name": "門鈴通知"
+            },
+            "low_temp_alarm": {
+                "name": "低溫警報"
+            },
+            "doorbell_recording": {
+                "name": "門鈴錄製"
+            }
+        },
+        "number": {
+            "volume": {
+                "name": "音量"
+            },
+            "system_volume": {
+                "name": "系統音量"
+            },
+            "alarm_volume": {
+                "name": "警報音量"
+            },
+            "doorbell_volume": {
+                "name": "門鈴音量"
+            },
+            "alarm_duration": {
+                "name": "警報時長"
+            },
+            "doorbell_duration": {
+                "name": "門鈴時長"
+            },
+            "music_volume": {
+                "name": "音樂音量"
+            },
+            "alarm_clock_volume": {
+                "name": "鬧鐘音量"
+            },
+            "night_light_brightness": {
+                "name": "夜燈亮度"
+            },
+            "arming_delay_time": {
+                "name": "佈防延遲時間"
+            },
+            "camera_volume": {
+                "name": "攝影機音量"
+            },
+            "face_recognition_interval": {
+                "name": "人臉辨識間隔"
+            }
+        },
+        "select": {
+            "gateway_language": {
+                "name": "閘道語言",
+                "state": {
+                    "chinese": "中文",
+                    "english": "英文"
+                }
+            },
+            "alarm_ringtone": {
+                "name": "警報鈴聲",
+                "state": {
+                    "default": "預設",
+                    "police_car_1": "警車聲 1",
+                    "police_car_2": "警車聲 2",
+                    "safety_accident": "安全事故聲",
+                    "missile_countdown": "飛彈倒數",
+                    "ghost_scream": "幽靈尖叫",
+                    "sniper_rifle": "狙擊步槍",
+                    "battle": "戰鬥聲",
+                    "air_raid_alarm": "空襲警報",
+                    "dog_barking": "狗叫聲"
+                }
+            },
+            "doorbell_ringtone": {
+                "name": "門鈴鈴聲",
+                "state": {
+                    "default": "預設",
+                    "index_0": "鈴聲 0",
+                    "index_1": "鈴聲 1",
+                    "index_2": "鈴聲 2",
+                    "index_3": "鈴聲 3",
+                    "index_4": "鈴聲 4",
+                    "index_5": "鈴聲 5",
+                    "index_6": "鈴聲 6",
+                    "index_7": "鈴聲 7",
+                    "index_8": "鈴聲 8"
+                }
+            },
+            "screen_flip": {
+                "name": "螢幕翻轉",
+                "state": {
+                    "normal": "正常",
+                    "flip_horizontally": "水平翻轉",
+                    "flip_vertically": "垂直翻轉",
+                    "flip_horizontally_and_vertically": "水平和垂直翻轉"
+                }
+            },
+            "camera_mode": {
+                "name": "攝影機模式",
+                "state": {
+                    "off": "關閉",
+                    "on": "開啟",
+                    "always_on": "始終開啟"
+                }
+            },
+            "work_mode": {
+                "name": "工作模式",
+                "state": {
+                    "radar_infrared": "雷達 + 紅外線",
+                    "radar_only": "僅雷達",
+                    "infrared_only": "僅紅外線"
+                }
+            }
+        },
+        "button": {
+            "ptz_up": {
+                "name": "向上"
+            },
+            "ptz_down": {
+                "name": "向下"
+            },
+            "ptz_left": {
+                "name": "向左"
+            },
+            "ptz_right": {
+                "name": "向右"
+            },
+            "ring_alarm_bell": {
+                "name": "響鈴警報"
+            },
+            "restart_device": {
+                "name": "重新啟動裝置"
+            },
+            "restart_coordinator": {
+                "name": "重新啟動協調器"
+            }
         }
     }
 }


### PR DESCRIPTION
Entity names, sensor states and select options were displayed in English in the device details, even though config-flow translations existed. Root cause: every entity class set _attr_name = spec["name"], which in Home Assistant takes absolute precedence over translation_key, so the existing binary_sensor translation keys never applied.

- Add translation_key to sensor/switch/number/select/button specs and stop setting _attr_name when a key is present (patron: only set _attr_name as a fallback when there is no translation_key).
- Translate enumerated states via SensorDeviceClass.ENUM + options: A100 lock (lock_state/door_event/open_door_method), FP2 modes and settings, FP300 activity_status. Convert value_map values to slugs.
- Translate select options by switching options to (api_value, slug) pairs and mapping the slug through entity.<platform>.<key>.state.
- Lean on native HA device-class names/states where they fit (temperature, humidity, illuminance, battery, motion, connectivity, occupancy, safety): drop name + translation_key so HA provides the translated name and on/off states automatically.
- Fill entity name/state translations in all 11 languages (en, fr, de, es, it, nl, hu, ru, cz, zh-Hans, zh-Hant).
- Clean up duplicate _attr_name assignment in number.py.

unique_id values are unchanged (still based on inApp/key), so existing user entities are not duplicated.