### PR TITLE
Add Aqara Xingyao (ACN002) door lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![HACS Action](https://github.com/Darkdragon14/ha-aqara-devices/actions/workflows/hacs_action.yml/badge.svg)](https://github.com/Darkdragon14/ha-aqara-devices/actions/workflows/hacs_action.yml)
 [![release](https://img.shields.io/github/v/release/Darkdragon14/ha-aqara-devices.svg)](https://github.com/Darkdragon14/ha-aqara-devices/releases)
 
-`Aqara Devices (G3, G2H Pro, G410, G4, M3, M100, FP2, FP300, and A100 Pro)` connects supported Aqara cameras, doorbells, hubs, presence sensors, and locks to Home Assistant with Aqara Open API v3 and `aqara-rocketmq-bridge`.
+`Aqara Devices (G3, G2H Pro, G410, G4, M3, M100, FP2, FP300, A100 Pro, and Xingyao/ACN002 locks)` connects supported Aqara cameras, doorbells, hubs, presence sensors, and locks to Home Assistant with Aqara Open API v3 and `aqara-rocketmq-bridge`.
 
 Instead of relying only on periodic polling, the integration now uses Aqara Message Push -> RocketMQ -> bridge -> Server-Sent Events (SSE) so Home Assistant receives live updates while the integration keeps Aqara authentication, token refresh, and resource subscriptions in sync.
 
@@ -113,6 +113,7 @@ After the first step, Aqara sends a verification code to your email address or p
 | `Presence Sensor FP2` | `lumi.motion.agl001` |
 | `Presence Multi-Sensor FP300` | `lumi.sensor_occupy.agl8` |
 | `Door Lock A100 Pro` | `aqara.lock.acn001` |
+| `Smart Video Door Lock Xingyao` (`全自动智能猫眼门锁 星耀`) | `aqara.lock.acn002` |
 
 Each discovered supported device in your Aqara account gets its own entities and device metadata inside Home Assistant.
 

--- a/custom_components/ha_aqara_devices/__init__.py
+++ b/custom_components/ha_aqara_devices/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     A100_PRO_MODELS,
+    ACN002_MODELS,
     BRIDGE_SANITY_INTERVAL_SECONDS,
     BRIDGE_UNAVAILABLE_AFTER_FAILURES,
     CONF_APP_ID,
@@ -108,6 +109,28 @@ def _create_resilient_coordinator(
     )
     hass.async_create_task(coordinator.async_refresh())
     return coordinator
+
+
+async def _async_refresh_coordinators_after_setup(
+    label: str,
+    coordinators: list[DataUpdateCoordinator],
+    delay_seconds: int = 5,
+) -> None:
+    """Refresh coordinators once after entities have subscribed to updates."""
+    if not coordinators:
+        return
+
+    await asyncio.sleep(delay_seconds)
+    for coordinator in coordinators:
+        try:
+            await coordinator.async_request_refresh()
+        except Exception as err:
+            _LOGGER.debug(
+                "Delayed Aqara %s refresh failed for %s: %s",
+                label,
+                coordinator.name,
+                err,
+            )
 
 
 def _setup_device_state_coordinators(
@@ -261,6 +284,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .api import AqaraApi, AqaraAuthError
     from .bridge_specs import (
         A100_PRO_STATE_SPECS,
+        ACN002_STATE_SPECS,
         G2H_PRO_STATE_SPECS,
         G410_STATE_SPECS,
         G4_STATE_SPECS,
@@ -310,6 +334,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs_m3 = [device for device in devices if device.get("model") in M3_MODELS]
         hubs_m100 = [device for device in devices if device.get("model") in M100_MODELS]
         a100_pro_locks = [device for device in devices if device.get("model") in A100_PRO_MODELS]
+        acn002_locks = [device for device in devices if device.get("model") in ACN002_MODELS]
         presence_devices = [device for device in devices if device.get("model") in PRESENCE_MODELS]
 
         if (
@@ -320,9 +345,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             and not hubs_m3
             and not hubs_m100
             and not a100_pro_locks
+            and not acn002_locks
             and not presence_devices
         ):
-            raise ConfigEntryNotReady("No Aqara G2H Pro, G3, G410, G4, M3, M100, A100 Pro, FP2, or FP300 devices found")
+            raise ConfigEntryNotReady(
+                "No Aqara G2H Pro, G3, G410, G4, M3, M100, A100 Pro, ACN002, FP2, or FP300 devices found"
+            )
 
     except (ConfigEntryAuthFailed, AqaraAuthError) as err:
         if isinstance(err, AqaraAuthError):
@@ -364,6 +392,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "a100-pro-state",
         A100_PRO_STATE_SPECS,
     )
+    acn002_coordinators = _setup_device_state_coordinators(
+        hass,
+        api,
+        acn002_locks,
+        "acn002-state",
+        ACN002_STATE_SPECS,
+    )
     presence_coordinators = _setup_presence_coordinators(hass, api, presence_devices)
 
     bridge_url = _entry_bridge_value(entry, CONF_BRIDGE_URL, DEFAULT_BRIDGE_URL)
@@ -380,6 +415,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "hubs_m3": hubs_m3,
         "hubs_m100": hubs_m100,
         "a100_pro_locks": a100_pro_locks,
+        "acn002_locks": acn002_locks,
         "presence_devices": presence_devices,
         "camera_coordinators": camera_coordinators,
         "g2h_pro_coordinators": g2h_pro_coordinators,
@@ -388,9 +424,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "m3_coordinators": m3_coordinators,
         "m100_coordinators": m100_coordinators,
         "a100_pro_coordinators": a100_pro_coordinators,
+        "acn002_coordinators": acn002_coordinators,
         "presence_coordinators": presence_coordinators,
         "bridge_manager": None,
         "bridge_task": None,
+        "warmup_tasks": [],
         "active_subscriptions": [],
     }
     hass.data[DOMAIN][entry.entry_id] = entry_data
@@ -412,6 +450,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs_m3,
         hubs_m100,
         a100_pro_locks,
+        acn002_locks,
         presence_devices,
     )
     entry_data["active_subscriptions"] = active_subscriptions
@@ -429,6 +468,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs_m3,
         hubs_m100,
         a100_pro_locks,
+        acn002_locks,
         presence_devices,
         camera_coordinators,
         g2h_pro_coordinators,
@@ -437,6 +477,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         m3_coordinators,
         m100_coordinators,
         a100_pro_coordinators,
+        acn002_coordinators,
         presence_coordinators,
         active_subscriptions,
     )
@@ -446,6 +487,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _async_start_bridge_with_retry(entry, bridge_manager),
         f"{DOMAIN} bridge startup",
     )
+    if acn002_coordinators:
+        entry_data["warmup_tasks"].append(
+            hass.async_create_background_task(
+                _async_refresh_coordinators_after_setup(
+                    "acn002-state",
+                    list(acn002_coordinators.values()),
+                ),
+                f"{DOMAIN} ACN002 delayed refresh",
+            )
+        )
 
     total_resources = sum(len(subscription["resourceIds"]) for subscription in active_subscriptions)
     _LOGGER.info(
@@ -487,6 +538,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bridge_task.cancel()
         with suppress(asyncio.CancelledError):
             await bridge_task
+    warmup_tasks = [] if entry_data is None else entry_data.get("warmup_tasks", [])
+    for task in warmup_tasks:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
     bridge_manager = None if entry_data is None else entry_data.get("bridge_manager")
     if bridge_manager is not None:

--- a/custom_components/ha_aqara_devices/bridge_specs.py
+++ b/custom_components/ha_aqara_devices/bridge_specs.py
@@ -16,7 +16,14 @@ from .fp2 import FP2_BINARY_SENSORS_DEF, FP2_SENSOR_SPECS
 from .fp300 import FP300_BINARY_SENSORS_DEF, FP300_SENSOR_SPECS
 from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, G4_NUMBERS_DEF, M100_NUMBERS_DEF, M3_NUMBERS_DEF
 from .selects import FP300_SELECTS_DEF, G410_SELECTS_DEF, G4_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
-from .sensors import A100_PRO_SENSORS_DEF, G410_SENSORS_DEF, G4_SENSORS_DEF, M100_SENSORS_DEF, M3_SENSORS_DEF
+from .sensors import (
+    A100_PRO_SENSORS_DEF,
+    ACN002_SENSORS_DEF,
+    G410_SENSORS_DEF,
+    G4_SENSORS_DEF,
+    M100_SENSORS_DEF,
+    M3_SENSORS_DEF,
+)
 from .switches import ALL_SWITCHES_DEF, G2H_PRO_SWITCHES_DEF, G410_SWITCHES_DEF, G4_SWITCHES_DEF, M100_SWITCHES_DEF
 
 
@@ -149,6 +156,12 @@ A100_PRO_STATE_SPECS = [
 A100_PRO_RESOURCE_SPEC_MAP = build_api_spec_map(A100_PRO_STATE_SPECS)
 A100_PRO_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(A100_PRO_STATE_SPECS)
 
+ACN002_STATE_SPECS = [
+    *ACN002_SENSORS_DEF,
+]
+ACN002_RESOURCE_SPEC_MAP = build_api_spec_map(ACN002_STATE_SPECS)
+ACN002_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(ACN002_STATE_SPECS)
+
 
 FP2_STATE_SPECS = [
     *FP2_BINARY_SENSORS_DEF,
@@ -261,6 +274,13 @@ def _collect_a100_pro_resources(enabled_unique_ids: set[str], did: str) -> list[
     return list(resource_ids)
 
 
+def _collect_acn002_resources(enabled_unique_ids: set[str], did: str) -> list[str]:
+    resource_ids: dict[str, None] = {}
+    for spec in ACN002_STATE_SPECS:
+        _append_resource_if_enabled(resource_ids, enabled_unique_ids, f"{did}_{spec['inApp']}", spec)
+    return list(resource_ids)
+
+
 def _collect_presence_resources(
     enabled_unique_ids: set[str],
     did: str,
@@ -287,6 +307,7 @@ def build_active_subscriptions(
     hubs_m3: list[dict[str, Any]],
     hubs_m100: list[dict[str, Any]],
     a100_pro_locks: list[dict[str, Any]],
+    acn002_locks: list[dict[str, Any]],
     presence_devices: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     subscriptions: list[dict[str, Any]] = []
@@ -330,6 +351,12 @@ def build_active_subscriptions(
     for lock in a100_pro_locks:
         did = str(lock["did"])
         resource_ids = _collect_a100_pro_resources(enabled_unique_ids, did)
+        if resource_ids:
+            subscriptions.append({"subjectId": did, "resourceIds": resource_ids})
+
+    for lock in acn002_locks:
+        did = str(lock["did"])
+        resource_ids = _collect_acn002_resources(enabled_unique_ids, did)
         if resource_ids:
             subscriptions.append({"subjectId": did, "resourceIds": resource_ids})
 

--- a/custom_components/ha_aqara_devices/const.py
+++ b/custom_components/ha_aqara_devices/const.py
@@ -35,6 +35,7 @@ G3_MODEL = "lumi.camera.gwpgl1"
 FP2_MODEL = "lumi.motion.agl001"
 FP300_MODEL = "lumi.sensor_occupy.agl8"
 A100_PRO_MODEL = "aqara.lock.acn001"
+ACN002_MODEL = "aqara.lock.acn002"
 G4_MODEL = "aqara.lock.agl002"
 G3_MODELS = {"lumi.camera.gwpgl1", "lumi.camera.gwpagl01"}
 G2H_PRO_MODELS = {"lumi.camera.agl001", "lumi.camera.acn003"}
@@ -42,6 +43,7 @@ G410_MODELS = {"lumi.camera.acn017", "lumi.camera.agl006"}
 M3_MODELS = {"lumi.gateway.acn012", "lumi.gateway.agl004"}
 M100_MODELS = {"lumi.gateway.agl008", "lumi.gateway.agl010"}
 A100_PRO_MODELS = {A100_PRO_MODEL}
+ACN002_MODELS = {ACN002_MODEL}
 G4_MODELS = {G4_MODEL, "lumi.camera.acn005"}
 PRESENCE_MODELS = {FP2_MODEL, FP300_MODEL}
 
@@ -53,6 +55,7 @@ M100_DEVICE_LABEL = "Aqara Hub M100"
 FP2_DEVICE_LABEL = "Aqara FP2"
 FP300_DEVICE_LABEL = "Presence Multi-Sensor FP300"
 A100_PRO_DEVICE_LABEL = "Aqara A100 Pro"
+ACN002_DEVICE_LABEL = "Aqara Smart Video Door Lock Xingyao"
 G4_DEVICE_LABEL = "Aqara G4"
 
 FP2_FAST_INTERVAL_SECONDS = 2

--- a/custom_components/ha_aqara_devices/push.py
+++ b/custom_components/ha_aqara_devices/push.py
@@ -16,6 +16,7 @@ from .const import BRIDGE_SANITY_INTERVAL_SECONDS
 from .api import AqaraApi, AqaraAuthError
 from .bridge_specs import (
     A100_PRO_RESOURCE_SPEC_MAP,
+    ACN002_RESOURCE_SPEC_MAP,
     FP2_GROUP_SPEC_MAPS,
     FP300_GROUP_SPEC_MAPS,
     G2H_PRO_RESOURCE_SPEC_MAP,
@@ -53,6 +54,7 @@ class AqaraBridgePushManager:
         hubs_m3: list[dict[str, Any]],
         hubs_m100: list[dict[str, Any]],
         a100_pro_locks: list[dict[str, Any]],
+        acn002_locks: list[dict[str, Any]],
         presence_devices: list[dict[str, Any]],
         camera_coordinators: dict[str, DataUpdateCoordinator],
         g2h_pro_coordinators: dict[str, DataUpdateCoordinator],
@@ -61,6 +63,7 @@ class AqaraBridgePushManager:
         m3_coordinators: dict[str, DataUpdateCoordinator],
         m100_coordinators: dict[str, DataUpdateCoordinator],
         a100_pro_coordinators: dict[str, DataUpdateCoordinator],
+        acn002_coordinators: dict[str, DataUpdateCoordinator],
         presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]],
         subscriptions: list[dict[str, Any]],
     ) -> None:
@@ -76,6 +79,7 @@ class AqaraBridgePushManager:
         self._m3_coordinators = m3_coordinators
         self._m100_coordinators = m100_coordinators
         self._a100_pro_coordinators = a100_pro_coordinators
+        self._acn002_coordinators = acn002_coordinators
         self._presence_coordinators = presence_coordinators
         self._cameras = {device["did"]: device for device in cameras}
         self._g2h_pro_cameras = {device["did"]: device for device in g2h_pro_cameras}
@@ -84,6 +88,7 @@ class AqaraBridgePushManager:
         self._hubs_m3 = {device["did"]: device for device in hubs_m3}
         self._hubs_m100 = {device["did"]: device for device in hubs_m100}
         self._a100_pro_locks = {device["did"]: device for device in a100_pro_locks}
+        self._acn002_locks = {device["did"]: device for device in acn002_locks}
         self._presence_devices = {device["did"]: device for device in presence_devices}
         self._camera_state: dict[str, dict[str, Any]] = {did: {} for did in self._cameras}
         self._g2h_pro_state: dict[str, dict[str, Any]] = {did: {} for did in self._g2h_pro_cameras}
@@ -92,6 +97,7 @@ class AqaraBridgePushManager:
         self._m3_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m3}
         self._m100_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m100}
         self._a100_pro_state: dict[str, dict[str, Any]] = {did: {} for did in self._a100_pro_locks}
+        self._acn002_state: dict[str, dict[str, Any]] = {did: {} for did in self._acn002_locks}
         self._presence_state: dict[str, dict[str, dict[str, Any]]] = {
             did: {group: {} for group in coordinators}
             for did, coordinators in presence_coordinators.items()
@@ -134,6 +140,7 @@ class AqaraBridgePushManager:
         yield from self._m3_coordinators.values()
         yield from self._m100_coordinators.values()
         yield from self._a100_pro_coordinators.values()
+        yield from self._acn002_coordinators.values()
         for groups in self._presence_coordinators.values():
             yield from groups.values()
 
@@ -465,6 +472,20 @@ class AqaraBridgePushManager:
             )
             return
 
+        if did in self._acn002_locks:
+            self._handle_shared_device_message(
+                payload_type,
+                did,
+                resource_id,
+                payload.get("value"),
+                self._acn002_coordinators,
+                self._acn002_state,
+                ACN002_RESOURCE_SPEC_MAP,
+                pending_updates,
+                apply_scale=True,
+            )
+            return
+
         device = self._presence_devices.get(did)
         if device is None:
             return
@@ -509,8 +530,9 @@ class AqaraBridgePushManager:
         if pending is not None:
             _, pending_state = pending
             return dict(pending_state)
-        if payload_type == "snapshot":
-            return {}
+        # The local bridge's SSE "snapshot" is a replay of recent events, not a
+        # complete state dump. Merge it into the existing coordinator data so
+        # fields missing from the replay do not regress to unknown.
         return dict(cached_state or coordinator.data or {})
 
     def _handle_g3_message(

--- a/custom_components/ha_aqara_devices/sensor.py
+++ b/custom_components/ha_aqara_devices/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     A100_PRO_DEVICE_LABEL,
+    ACN002_DEVICE_LABEL,
     DOMAIN,
     FP2_DEVICE_LABEL,
     FP2_MODEL,
@@ -28,6 +29,7 @@ from .fp300 import FP300_SENSOR_SPECS
 from .fp2 import FP2_SENSOR_SPECS
 from .sensors import (
     A100_PRO_SENSORS_DEF,
+    ACN002_SENSORS_DEF,
     G410_SENSORS_DEF,
     G4_SENSORS_DEF,
     M100_SENSORS_DEF,
@@ -44,12 +46,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hubs_m3: list[dict] = data.get("hubs_m3", [])
     hubs_m100: list[dict] = data.get("hubs_m100", [])
     a100_pro_locks: list[dict] = data.get("a100_pro_locks", [])
+    acn002_locks: list[dict] = data.get("acn002_locks", [])
     presence_devices: list[dict] = data.get("presence_devices", [])
     g410_coordinators: dict[str, DataUpdateCoordinator] = data.get("g410_coordinators", {})
     g4_coordinators: dict[str, DataUpdateCoordinator] = data.get("g4_coordinators", {})
     m3_coordinators: dict[str, DataUpdateCoordinator] = data.get("m3_coordinators", {})
     m100_coordinators: dict[str, DataUpdateCoordinator] = data.get("m100_coordinators", {})
     a100_pro_coordinators: dict[str, DataUpdateCoordinator] = data.get("a100_pro_coordinators", {})
+    acn002_coordinators: dict[str, DataUpdateCoordinator] = data.get("acn002_coordinators", {})
     presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]] = data.get("presence_coordinators", {})
 
     entities: list[SensorEntity] = []
@@ -154,6 +158,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 )
             )
 
+    for lock in acn002_locks:
+        did = lock["did"]
+        name = lock["deviceName"]
+        model = lock["model"]
+        coordinator = acn002_coordinators.get(did)
+        if coordinator is None:
+            continue
+
+        for sensor_def in ACN002_SENSORS_DEF:
+            entities.append(
+                AqaraSensor(
+                    coordinator,
+                    did,
+                    name,
+                    sensor_def,
+                    model,
+                    ACN002_DEVICE_LABEL,
+                )
+            )
+
     for presence in presence_devices:
         did = presence["did"]
         name = presence["deviceName"]
@@ -216,6 +240,7 @@ class AqaraSensor(CoordinatorEntity, SensorEntity):
             self._attr_name = spec["name"]
         self._attr_icon = spec.get("icon")
         self._attr_native_unit_of_measurement = spec.get("unit")
+        self._attr_options = None
         options = spec.get("options")
         if options is not None:
             self._attr_options = options
@@ -293,6 +318,7 @@ class AqaraFP2Sensor(CoordinatorEntity, SensorEntity):
         self._attr_native_unit_of_measurement = spec.get("unit")
         self._attr_device_class = spec.get("device_class")
         self._attr_state_class = spec.get("state_class")
+        self._attr_options = None
         options = spec.get("options")
         if options is not None:
             self._attr_options = options

--- a/custom_components/ha_aqara_devices/sensors.py
+++ b/custom_components/ha_aqara_devices/sensors.py
@@ -254,3 +254,62 @@ A100_PRO_SENSORS_DEF = [
     A100_PRO_USER_ID_BLE_HOMEKIT,
     A100_PRO_USER_ID_TEMPORARY_PASSWORD,
 ]
+
+ACN002_BATTERY_LEVEL = {
+    "name": "Battery Level",
+    "icon": "mdi:battery",
+    "inApp": "battery_level",
+    "api": "3.19.85",
+    "value_type": "float",
+    "device_class": "battery",
+    "state_class": "measurement",
+    "unit": PERCENTAGE,
+    "default": None,
+}
+
+ACN002_LOCK_EXCEPTION = {
+    "name": "Lock Exception Alert",
+    "icon": "mdi:lock-alert",
+    "inApp": "lock_exception_alert",
+    "api": "13.32.85",
+    "value_type": "uint32_t",
+    "default": None,
+}
+
+ACN002_DEVICE_ONLINE_STATUS = {
+    "name": "Device Online Status",
+    "icon": "mdi:lan-connect",
+    "inApp": "device_online_status",
+    "api": "8.0.2045",
+    "value_type": "uint8_t",
+    "device_class": "enum",
+    "value_map": {
+        "0": "offline",
+        "1": "online",
+    },
+    "options": [
+        "offline",
+        "online",
+    ],
+    "default": None,
+}
+
+ACN002_ZIGBEE_SIGNAL_STRENGTH = {
+    "name": "Zigbee Signal Strength",
+    "icon": "mdi:signal",
+    "inApp": "zigbee_signal_strength",
+    "api": "8.0.2007",
+    "value_type": "uint8_t",
+    "state_class": "measurement",
+    "default": None,
+}
+
+ACN002_SENSORS_DEF = [
+    A100_PRO_DOOR_EVENT,
+    A100_PRO_LOCK_STATE,
+    A100_PRO_OPEN_DOOR_METHOD,
+    ACN002_BATTERY_LEVEL,
+    ACN002_LOCK_EXCEPTION,
+    ACN002_DEVICE_ONLINE_STATUS,
+    ACN002_ZIGBEE_SIGNAL_STRENGTH,
+]


### PR DESCRIPTION
## Summary

- Add `aqara.lock.acn002` as Aqara Smart Video Door Lock Xingyao (`全自动智能猫眼门锁 星耀`).
- Wire ACN002 locks into device discovery, coordinators, resource subscriptions, and SSE push handling.
- Reuse the existing A100 Pro door event / lock state / open method resources, and add ACN002 battery, exception, online status, and Zigbee signal sensors.
- Preserve existing coordinator data when the local bridge sends an SSE `snapshot`, because the bridge snapshot is a replay of recent events rather than a complete state dump.
- Trigger one delayed refresh after ACN002 entities are added so state is populated after Home Assistant restart without waiting for the next push event.

## Validation

- `git diff --check`
- `python3 -m compileall -q custom_components/ha_aqara_devices`
- Tested locally with ACN002 locks through `aqara-rocketmq-bridge`; lock status, online status, and Zigbee signal entities populate after restart and update from push events.