### PR TITLE
Add Aqara Xingyao (ACN002) door lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![HACS Action](https://github.com/Darkdragon14/ha-aqara-devices/actions/workflows/hacs_action.yml/badge.svg)](https://github.com/Darkdragon14/ha-aqara-devices/actions/workflows/hacs_action.yml)
 [![release](https://img.shields.io/github/v/release/Darkdragon14/ha-aqara-devices.svg)](https://github.com/Darkdragon14/ha-aqara-devices/releases)
 
-`Aqara Devices (G3, G2H Pro, G410, G4, M3, M100, FP2, FP300, and A100 Pro)` connects supported Aqara cameras, doorbells, hubs, presence sensors, and locks to Home Assistant with Aqara Open API v3 and `aqara-rocketmq-bridge`.
+`Aqara Devices (G3, G2H Pro, G410, G4, M3, M100, FP2, FP300, A100 Pro, and Xingyao/ACN002 locks)` connects supported Aqara cameras, doorbells, hubs, presence sensors, and locks to Home Assistant with Aqara Open API v3 and `aqara-rocketmq-bridge`.
 
 Instead of relying only on periodic polling, the integration now uses Aqara Message Push -> RocketMQ -> bridge -> Server-Sent Events (SSE) so Home Assistant receives live updates while the integration keeps Aqara authentication, token refresh, and resource subscriptions in sync.
 
@@ -113,6 +113,7 @@ After the first step, Aqara sends a verification code to your email address or p
 | `Presence Sensor FP2` | `lumi.motion.agl001` |
 | `Presence Multi-Sensor FP300` | `lumi.sensor_occupy.agl8` |
 | `Door Lock A100 Pro` | `aqara.lock.acn001` |
+| `Smart Video Door Lock Xingyao` (`全自动智能猫眼门锁 星耀`) | `aqara.lock.acn002` |
 
 Each discovered supported device in your Aqara account gets its own entities and device metadata inside Home Assistant.
 

--- a/custom_components/ha_aqara_devices/__init__.py
+++ b/custom_components/ha_aqara_devices/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     A100_PRO_MODELS,
+    ACN002_MODELS,
     BRIDGE_SANITY_INTERVAL_SECONDS,
     BRIDGE_UNAVAILABLE_AFTER_FAILURES,
     CONF_APP_ID,
@@ -108,6 +109,28 @@ def _create_resilient_coordinator(
     )
     hass.async_create_task(coordinator.async_refresh())
     return coordinator
+
+
+async def _async_refresh_coordinators_after_setup(
+    label: str,
+    coordinators: list[DataUpdateCoordinator],
+    delay_seconds: int = 5,
+) -> None:
+    """Refresh coordinators once after entities have subscribed to updates."""
+    if not coordinators:
+        return
+
+    await asyncio.sleep(delay_seconds)
+    for coordinator in coordinators:
+        try:
+            await coordinator.async_request_refresh()
+        except Exception as err:
+            _LOGGER.debug(
+                "Delayed Aqara %s refresh failed for %s: %s",
+                label,
+                coordinator.name,
+                err,
+            )
 
 
 def _setup_device_state_coordinators(
@@ -261,6 +284,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .api import AqaraApi, AqaraAuthError
     from .bridge_specs import (
         A100_PRO_STATE_SPECS,
+        ACN002_STATE_SPECS,
         G2H_PRO_STATE_SPECS,
         G410_STATE_SPECS,
         G4_STATE_SPECS,
@@ -310,6 +334,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs_m3 = [device for device in devices if device.get("model") in M3_MODELS]
         hubs_m100 = [device for device in devices if device.get("model") in M100_MODELS]
         a100_pro_locks = [device for device in devices if device.get("model") in A100_PRO_MODELS]
+        acn002_locks = [device for device in devices if device.get("model") in ACN002_MODELS]
         presence_devices = [device for device in devices if device.get("model") in PRESENCE_MODELS]
 
         if (
@@ -320,9 +345,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             and not hubs_m3
             and not hubs_m100
             and not a100_pro_locks
+            and not acn002_locks
             and not presence_devices
         ):
-            raise ConfigEntryNotReady("No Aqara G2H Pro, G3, G410, G4, M3, M100, A100 Pro, FP2, or FP300 devices found")
+            raise ConfigEntryNotReady("No Aqara G2H Pro, G3, G410, G4, M3, M100, A100 Pro, ACN002, FP2, or FP300 devices found")
 
     except (ConfigEntryAuthFailed, AqaraAuthError) as err:
         if isinstance(err, AqaraAuthError):
@@ -364,6 +390,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "a100-pro-state",
         A100_PRO_STATE_SPECS,
     )
+    acn002_coordinators = _setup_device_state_coordinators(
+        hass,
+        api,
+        acn002_locks,
+        "acn002-state",
+        ACN002_STATE_SPECS,
+    )
     presence_coordinators = _setup_presence_coordinators(hass, api, presence_devices)
 
     bridge_url = _entry_bridge_value(entry, CONF_BRIDGE_URL, DEFAULT_BRIDGE_URL)
@@ -380,6 +413,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "hubs_m3": hubs_m3,
         "hubs_m100": hubs_m100,
         "a100_pro_locks": a100_pro_locks,
+        "acn002_locks": acn002_locks,
         "presence_devices": presence_devices,
         "camera_coordinators": camera_coordinators,
         "g2h_pro_coordinators": g2h_pro_coordinators,
@@ -388,9 +422,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "m3_coordinators": m3_coordinators,
         "m100_coordinators": m100_coordinators,
         "a100_pro_coordinators": a100_pro_coordinators,
+        "acn002_coordinators": acn002_coordinators,
         "presence_coordinators": presence_coordinators,
         "bridge_manager": None,
         "bridge_task": None,
+        "warmup_tasks": [],
         "active_subscriptions": [],
     }
     hass.data[DOMAIN][entry.entry_id] = entry_data
@@ -412,6 +448,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs_m3,
         hubs_m100,
         a100_pro_locks,
+        acn002_locks,
         presence_devices,
     )
     entry_data["active_subscriptions"] = active_subscriptions
@@ -429,6 +466,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hubs_m3,
         hubs_m100,
         a100_pro_locks,
+        acn002_locks,
         presence_devices,
         camera_coordinators,
         g2h_pro_coordinators,
@@ -437,6 +475,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         m3_coordinators,
         m100_coordinators,
         a100_pro_coordinators,
+        acn002_coordinators,
         presence_coordinators,
         active_subscriptions,
     )
@@ -446,6 +485,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _async_start_bridge_with_retry(entry, bridge_manager),
         f"{DOMAIN} bridge startup",
     )
+    if acn002_coordinators:
+        entry_data["warmup_tasks"].append(
+            hass.async_create_background_task(
+                _async_refresh_coordinators_after_setup(
+                    "acn002-state",
+                    list(acn002_coordinators.values()),
+                ),
+                f"{DOMAIN} ACN002 delayed refresh",
+            )
+        )
 
     total_resources = sum(len(subscription["resourceIds"]) for subscription in active_subscriptions)
     _LOGGER.info(
@@ -487,6 +536,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bridge_task.cancel()
         with suppress(asyncio.CancelledError):
             await bridge_task
+    warmup_tasks = [] if entry_data is None else entry_data.get("warmup_tasks", [])
+    for task in warmup_tasks:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
     bridge_manager = None if entry_data is None else entry_data.get("bridge_manager")
     if bridge_manager is not None:

--- a/custom_components/ha_aqara_devices/bridge_specs.py
+++ b/custom_components/ha_aqara_devices/bridge_specs.py
@@ -16,7 +16,7 @@ from .fp2 import FP2_BINARY_SENSORS_DEF, FP2_SENSOR_SPECS
 from .fp300 import FP300_BINARY_SENSORS_DEF, FP300_SENSOR_SPECS
 from .numbers import ALL_NUMBERS_DEF, G2H_PRO_NUMBERS_DEF, G410_NUMBERS_DEF, G4_NUMBERS_DEF, M100_NUMBERS_DEF, M3_NUMBERS_DEF
 from .selects import FP300_SELECTS_DEF, G410_SELECTS_DEF, G4_SELECTS_DEF, M100_SELECTS_DEF, M3_SELECTS_DEF
-from .sensors import A100_PRO_SENSORS_DEF, G410_SENSORS_DEF, G4_SENSORS_DEF, M100_SENSORS_DEF, M3_SENSORS_DEF
+from .sensors import A100_PRO_SENSORS_DEF, ACN002_SENSORS_DEF, G410_SENSORS_DEF, G4_SENSORS_DEF, M100_SENSORS_DEF, M3_SENSORS_DEF
 from .switches import ALL_SWITCHES_DEF, G2H_PRO_SWITCHES_DEF, G410_SWITCHES_DEF, G4_SWITCHES_DEF, M100_SWITCHES_DEF
 
 
@@ -149,6 +149,12 @@ A100_PRO_STATE_SPECS = [
 A100_PRO_RESOURCE_SPEC_MAP = build_api_spec_map(A100_PRO_STATE_SPECS)
 A100_PRO_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(A100_PRO_STATE_SPECS)
 
+ACN002_STATE_SPECS = [
+    *ACN002_SENSORS_DEF,
+]
+ACN002_RESOURCE_SPEC_MAP = build_api_spec_map(ACN002_STATE_SPECS)
+ACN002_SUBSCRIPTION_RESOURCE_IDS = unique_api_resource_ids(ACN002_STATE_SPECS)
+
 
 FP2_STATE_SPECS = [
     *FP2_BINARY_SENSORS_DEF,
@@ -261,6 +267,13 @@ def _collect_a100_pro_resources(enabled_unique_ids: set[str], did: str) -> list[
     return list(resource_ids)
 
 
+def _collect_acn002_resources(enabled_unique_ids: set[str], did: str) -> list[str]:
+    resource_ids: dict[str, None] = {}
+    for spec in ACN002_STATE_SPECS:
+        _append_resource_if_enabled(resource_ids, enabled_unique_ids, f"{did}_{spec['inApp']}", spec)
+    return list(resource_ids)
+
+
 def _collect_presence_resources(
     enabled_unique_ids: set[str],
     did: str,
@@ -287,6 +300,7 @@ def build_active_subscriptions(
     hubs_m3: list[dict[str, Any]],
     hubs_m100: list[dict[str, Any]],
     a100_pro_locks: list[dict[str, Any]],
+    acn002_locks: list[dict[str, Any]],
     presence_devices: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     subscriptions: list[dict[str, Any]] = []
@@ -330,6 +344,12 @@ def build_active_subscriptions(
     for lock in a100_pro_locks:
         did = str(lock["did"])
         resource_ids = _collect_a100_pro_resources(enabled_unique_ids, did)
+        if resource_ids:
+            subscriptions.append({"subjectId": did, "resourceIds": resource_ids})
+
+    for lock in acn002_locks:
+        did = str(lock["did"])
+        resource_ids = _collect_acn002_resources(enabled_unique_ids, did)
         if resource_ids:
             subscriptions.append({"subjectId": did, "resourceIds": resource_ids})
 

--- a/custom_components/ha_aqara_devices/const.py
+++ b/custom_components/ha_aqara_devices/const.py
@@ -35,6 +35,7 @@ G3_MODEL = "lumi.camera.gwpgl1"
 FP2_MODEL = "lumi.motion.agl001"
 FP300_MODEL = "lumi.sensor_occupy.agl8"
 A100_PRO_MODEL = "aqara.lock.acn001"
+ACN002_MODEL = "aqara.lock.acn002"
 G4_MODEL = "aqara.lock.agl002"
 G3_MODELS = {"lumi.camera.gwpgl1", "lumi.camera.gwpagl01"}
 G2H_PRO_MODELS = {"lumi.camera.agl001", "lumi.camera.acn003"}
@@ -42,6 +43,7 @@ G410_MODELS = {"lumi.camera.acn017", "lumi.camera.agl006"}
 M3_MODELS = {"lumi.gateway.acn012", "lumi.gateway.agl004"}
 M100_MODELS = {"lumi.gateway.agl008", "lumi.gateway.agl010"}
 A100_PRO_MODELS = {A100_PRO_MODEL}
+ACN002_MODELS = {ACN002_MODEL}
 G4_MODELS = {G4_MODEL, "lumi.camera.acn005"}
 PRESENCE_MODELS = {FP2_MODEL, FP300_MODEL}
 
@@ -53,6 +55,7 @@ M100_DEVICE_LABEL = "Aqara Hub M100"
 FP2_DEVICE_LABEL = "Aqara FP2"
 FP300_DEVICE_LABEL = "Presence Multi-Sensor FP300"
 A100_PRO_DEVICE_LABEL = "Aqara A100 Pro"
+ACN002_DEVICE_LABEL = "Aqara Smart Video Door Lock Xingyao"
 G4_DEVICE_LABEL = "Aqara G4"
 
 FP2_FAST_INTERVAL_SECONDS = 2

--- a/custom_components/ha_aqara_devices/push.py
+++ b/custom_components/ha_aqara_devices/push.py
@@ -16,6 +16,7 @@ from .const import BRIDGE_SANITY_INTERVAL_SECONDS
 from .api import AqaraApi, AqaraAuthError
 from .bridge_specs import (
     A100_PRO_RESOURCE_SPEC_MAP,
+    ACN002_RESOURCE_SPEC_MAP,
     FP2_GROUP_SPEC_MAPS,
     FP300_GROUP_SPEC_MAPS,
     G2H_PRO_RESOURCE_SPEC_MAP,
@@ -53,6 +54,7 @@ class AqaraBridgePushManager:
         hubs_m3: list[dict[str, Any]],
         hubs_m100: list[dict[str, Any]],
         a100_pro_locks: list[dict[str, Any]],
+        acn002_locks: list[dict[str, Any]],
         presence_devices: list[dict[str, Any]],
         camera_coordinators: dict[str, DataUpdateCoordinator],
         g2h_pro_coordinators: dict[str, DataUpdateCoordinator],
@@ -61,6 +63,7 @@ class AqaraBridgePushManager:
         m3_coordinators: dict[str, DataUpdateCoordinator],
         m100_coordinators: dict[str, DataUpdateCoordinator],
         a100_pro_coordinators: dict[str, DataUpdateCoordinator],
+        acn002_coordinators: dict[str, DataUpdateCoordinator],
         presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]],
         subscriptions: list[dict[str, Any]],
     ) -> None:
@@ -76,6 +79,7 @@ class AqaraBridgePushManager:
         self._m3_coordinators = m3_coordinators
         self._m100_coordinators = m100_coordinators
         self._a100_pro_coordinators = a100_pro_coordinators
+        self._acn002_coordinators = acn002_coordinators
         self._presence_coordinators = presence_coordinators
         self._cameras = {device["did"]: device for device in cameras}
         self._g2h_pro_cameras = {device["did"]: device for device in g2h_pro_cameras}
@@ -84,6 +88,7 @@ class AqaraBridgePushManager:
         self._hubs_m3 = {device["did"]: device for device in hubs_m3}
         self._hubs_m100 = {device["did"]: device for device in hubs_m100}
         self._a100_pro_locks = {device["did"]: device for device in a100_pro_locks}
+        self._acn002_locks = {device["did"]: device for device in acn002_locks}
         self._presence_devices = {device["did"]: device for device in presence_devices}
         self._camera_state: dict[str, dict[str, Any]] = {did: {} for did in self._cameras}
         self._g2h_pro_state: dict[str, dict[str, Any]] = {did: {} for did in self._g2h_pro_cameras}
@@ -92,6 +97,7 @@ class AqaraBridgePushManager:
         self._m3_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m3}
         self._m100_state: dict[str, dict[str, Any]] = {did: {} for did in self._hubs_m100}
         self._a100_pro_state: dict[str, dict[str, Any]] = {did: {} for did in self._a100_pro_locks}
+        self._acn002_state: dict[str, dict[str, Any]] = {did: {} for did in self._acn002_locks}
         self._presence_state: dict[str, dict[str, dict[str, Any]]] = {
             did: {group: {} for group in coordinators}
             for did, coordinators in presence_coordinators.items()
@@ -134,6 +140,7 @@ class AqaraBridgePushManager:
         yield from self._m3_coordinators.values()
         yield from self._m100_coordinators.values()
         yield from self._a100_pro_coordinators.values()
+        yield from self._acn002_coordinators.values()
         for groups in self._presence_coordinators.values():
             yield from groups.values()
 
@@ -465,6 +472,20 @@ class AqaraBridgePushManager:
             )
             return
 
+        if did in self._acn002_locks:
+            self._handle_shared_device_message(
+                payload_type,
+                did,
+                resource_id,
+                payload.get("value"),
+                self._acn002_coordinators,
+                self._acn002_state,
+                ACN002_RESOURCE_SPEC_MAP,
+                pending_updates,
+                apply_scale=True,
+            )
+            return
+
         device = self._presence_devices.get(did)
         if device is None:
             return
@@ -509,8 +530,9 @@ class AqaraBridgePushManager:
         if pending is not None:
             _, pending_state = pending
             return dict(pending_state)
-        if payload_type == "snapshot":
-            return {}
+        # The local bridge's SSE "snapshot" is a replay of recent events, not a
+        # complete state dump. Merge it into the existing coordinator data so
+        # fields missing from the replay do not regress to unknown.
         return dict(cached_state or coordinator.data or {})
 
     def _handle_g3_message(

--- a/custom_components/ha_aqara_devices/sensor.py
+++ b/custom_components/ha_aqara_devices/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     A100_PRO_DEVICE_LABEL,
+    ACN002_DEVICE_LABEL,
     DOMAIN,
     FP2_DEVICE_LABEL,
     FP2_MODEL,
@@ -28,6 +29,7 @@ from .fp300 import FP300_SENSOR_SPECS
 from .fp2 import FP2_SENSOR_SPECS
 from .sensors import (
     A100_PRO_SENSORS_DEF,
+    ACN002_SENSORS_DEF,
     G410_SENSORS_DEF,
     G4_SENSORS_DEF,
     M100_SENSORS_DEF,
@@ -44,12 +46,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     hubs_m3: list[dict] = data.get("hubs_m3", [])
     hubs_m100: list[dict] = data.get("hubs_m100", [])
     a100_pro_locks: list[dict] = data.get("a100_pro_locks", [])
+    acn002_locks: list[dict] = data.get("acn002_locks", [])
     presence_devices: list[dict] = data.get("presence_devices", [])
     g410_coordinators: dict[str, DataUpdateCoordinator] = data.get("g410_coordinators", {})
     g4_coordinators: dict[str, DataUpdateCoordinator] = data.get("g4_coordinators", {})
     m3_coordinators: dict[str, DataUpdateCoordinator] = data.get("m3_coordinators", {})
     m100_coordinators: dict[str, DataUpdateCoordinator] = data.get("m100_coordinators", {})
     a100_pro_coordinators: dict[str, DataUpdateCoordinator] = data.get("a100_pro_coordinators", {})
+    acn002_coordinators: dict[str, DataUpdateCoordinator] = data.get("acn002_coordinators", {})
     presence_coordinators: dict[str, dict[str, DataUpdateCoordinator]] = data.get("presence_coordinators", {})
 
     entities: list[SensorEntity] = []
@@ -154,6 +158,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 )
             )
 
+    for lock in acn002_locks:
+        did = lock["did"]
+        name = lock["deviceName"]
+        model = lock["model"]
+        coordinator = acn002_coordinators.get(did)
+        if coordinator is None:
+            continue
+
+        for sensor_def in ACN002_SENSORS_DEF:
+            entities.append(
+                AqaraSensor(
+                    coordinator,
+                    did,
+                    name,
+                    sensor_def,
+                    model,
+                    ACN002_DEVICE_LABEL,
+                )
+            )
+
     for presence in presence_devices:
         did = presence["did"]
         name = presence["deviceName"]
@@ -216,6 +240,7 @@ class AqaraSensor(CoordinatorEntity, SensorEntity):
             self._attr_name = spec["name"]
         self._attr_icon = spec.get("icon")
         self._attr_native_unit_of_measurement = spec.get("unit")
+        self._attr_options = None
         options = spec.get("options")
         if options is not None:
             self._attr_options = options
@@ -293,6 +318,7 @@ class AqaraFP2Sensor(CoordinatorEntity, SensorEntity):
         self._attr_native_unit_of_measurement = spec.get("unit")
         self._attr_device_class = spec.get("device_class")
         self._attr_state_class = spec.get("state_class")
+        self._attr_options = None
         options = spec.get("options")
         if options is not None:
             self._attr_options = options

--- a/custom_components/ha_aqara_devices/sensors.py
+++ b/custom_components/ha_aqara_devices/sensors.py
@@ -257,6 +257,7 @@ A100_PRO_SENSORS_DEF = [
 
 ACN002_LOCK_EXCEPTION = {
     "name": "Lock Exception Alert",
+    "translation_key": "lock_exception_alert",
     "icon": "mdi:lock-alert",
     "inApp": "lock_exception_alert",
     "api": "13.32.85",
@@ -266,6 +267,7 @@ ACN002_LOCK_EXCEPTION = {
 
 ACN002_DEVICE_ONLINE_STATUS = {
     "name": "Device Online Status",
+    "translation_key": "device_online_status",
     "icon": "mdi:lan-connect",
     "inApp": "device_online_status",
     "api": "8.0.2045",
@@ -284,6 +286,7 @@ ACN002_DEVICE_ONLINE_STATUS = {
 
 ACN002_ZIGBEE_SIGNAL_STRENGTH = {
     "name": "Zigbee Signal Strength",
+    "translation_key": "zigbee_signal_strength",
     "icon": "mdi:signal",
     "inApp": "zigbee_signal_strength",
     "api": "8.0.2007",

--- a/custom_components/ha_aqara_devices/sensors.py
+++ b/custom_components/ha_aqara_devices/sensors.py
@@ -254,3 +254,49 @@ A100_PRO_SENSORS_DEF = [
     A100_PRO_USER_ID_BLE_HOMEKIT,
     A100_PRO_USER_ID_TEMPORARY_PASSWORD,
 ]
+
+ACN002_LOCK_EXCEPTION = {
+    "name": "Lock Exception Alert",
+    "icon": "mdi:lock-alert",
+    "inApp": "lock_exception_alert",
+    "api": "13.32.85",
+    "value_type": "uint32_t",
+    "default": None,
+}
+
+ACN002_DEVICE_ONLINE_STATUS = {
+    "name": "Device Online Status",
+    "icon": "mdi:lan-connect",
+    "inApp": "device_online_status",
+    "api": "8.0.2045",
+    "value_type": "uint8_t",
+    "device_class": "enum",
+    "value_map": {
+        "0": "offline",
+        "1": "online",
+    },
+    "options": [
+        "offline",
+        "online",
+    ],
+    "default": None,
+}
+
+ACN002_ZIGBEE_SIGNAL_STRENGTH = {
+    "name": "Zigbee Signal Strength",
+    "icon": "mdi:signal",
+    "inApp": "zigbee_signal_strength",
+    "api": "8.0.2007",
+    "value_type": "uint8_t",
+    "state_class": "measurement",
+    "default": None,
+}
+
+ACN002_SENSORS_DEF = [
+    A100_PRO_DOOR_EVENT,
+    A100_PRO_LOCK_STATE,
+    A100_PRO_OPEN_DOOR_METHOD,
+    ACN002_LOCK_EXCEPTION,
+    ACN002_DEVICE_ONLINE_STATUS,
+    ACN002_ZIGBEE_SIGNAL_STRENGTH,
+]

--- a/custom_components/ha_aqara_devices/translations/cz.json
+++ b/custom_components/ha_aqara_devices/translations/cz.json
@@ -172,6 +172,19 @@
             "user_id_temporary_password": {
                 "name": "ID uživatele dočasného hesla"
             },
+            "lock_exception_alert": {
+                "name": "Upozornění na chybu zámku"
+            },
+            "device_online_status": {
+                "name": "Online stav zařízení",
+                "state": {
+                    "offline": "Offline",
+                    "online": "Online"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Síla signálu Zigbee"
+            },
             "people_counting": {
                 "name": "Počítání osob"
             },

--- a/custom_components/ha_aqara_devices/translations/de.json
+++ b/custom_components/ha_aqara_devices/translations/de.json
@@ -145,6 +145,19 @@
             "user_id_temporary_password": {
                 "name": "Benutzer-ID temporäres Passwort"
             },
+            "lock_exception_alert": {
+                "name": "Schloss-Fehleralarm"
+            },
+            "device_online_status": {
+                "name": "Geräte-Onlinestatus",
+                "state": {
+                    "offline": "Offline",
+                    "online": "Online"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Zigbee-Signalstärke"
+            },
             "people_counting": {
                 "name": "Personenzählung"
             },

--- a/custom_components/ha_aqara_devices/translations/en.json
+++ b/custom_components/ha_aqara_devices/translations/en.json
@@ -172,6 +172,19 @@
             "user_id_temporary_password": {
                 "name": "Temporary Password User ID"
             },
+            "lock_exception_alert": {
+                "name": "Lock Exception Alert"
+            },
+            "device_online_status": {
+                "name": "Device Online Status",
+                "state": {
+                    "offline": "Offline",
+                    "online": "Online"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Zigbee Signal Strength"
+            },
             "people_counting": {
                 "name": "People Counting"
             },

--- a/custom_components/ha_aqara_devices/translations/es.json
+++ b/custom_components/ha_aqara_devices/translations/es.json
@@ -145,6 +145,19 @@
             "user_id_temporary_password": {
                 "name": "ID de usuario de contraseña temporal"
             },
+            "lock_exception_alert": {
+                "name": "Alerta de excepción de cerradura"
+            },
+            "device_online_status": {
+                "name": "Estado en línea del dispositivo",
+                "state": {
+                    "offline": "Sin conexión",
+                    "online": "En línea"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Intensidad de señal Zigbee"
+            },
             "people_counting": {
                 "name": "Recuento de personas"
             },

--- a/custom_components/ha_aqara_devices/translations/fr.json
+++ b/custom_components/ha_aqara_devices/translations/fr.json
@@ -172,6 +172,19 @@
             "user_id_temporary_password": {
                 "name": "ID utilisateur mot de passe temporaire"
             },
+            "lock_exception_alert": {
+                "name": "Alerte d'anomalie de serrure"
+            },
+            "device_online_status": {
+                "name": "État de connexion de l'appareil",
+                "state": {
+                    "offline": "Hors ligne",
+                    "online": "En ligne"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Puissance du signal Zigbee"
+            },
             "people_counting": {
                 "name": "Comptage de personnes"
             },

--- a/custom_components/ha_aqara_devices/translations/hu.json
+++ b/custom_components/ha_aqara_devices/translations/hu.json
@@ -145,6 +145,19 @@
             "user_id_temporary_password": {
                 "name": "Ideiglenes jelszó felhasználói azonosító"
             },
+            "lock_exception_alert": {
+                "name": "Zárhiba riasztás"
+            },
+            "device_online_status": {
+                "name": "Eszköz online állapota",
+                "state": {
+                    "offline": "Offline",
+                    "online": "Online"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Zigbee jelerősség"
+            },
             "people_counting": {
                 "name": "Emberszámlálás"
             },

--- a/custom_components/ha_aqara_devices/translations/it.json
+++ b/custom_components/ha_aqara_devices/translations/it.json
@@ -145,6 +145,19 @@
             "user_id_temporary_password": {
                 "name": "ID utente password temporanea"
             },
+            "lock_exception_alert": {
+                "name": "Avviso anomalia serratura"
+            },
+            "device_online_status": {
+                "name": "Stato online dispositivo",
+                "state": {
+                    "offline": "Offline",
+                    "online": "Online"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Intensità segnale Zigbee"
+            },
             "people_counting": {
                 "name": "Conteggio persone"
             },

--- a/custom_components/ha_aqara_devices/translations/nl.json
+++ b/custom_components/ha_aqara_devices/translations/nl.json
@@ -145,6 +145,19 @@
             "user_id_temporary_password": {
                 "name": "Gebruikers-ID tijdelijk wachtwoord"
             },
+            "lock_exception_alert": {
+                "name": "Waarschuwing slotafwijking"
+            },
+            "device_online_status": {
+                "name": "Online status apparaat",
+                "state": {
+                    "offline": "Offline",
+                    "online": "Online"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Zigbee-signaalsterkte"
+            },
             "people_counting": {
                 "name": "Personen tellen"
             },

--- a/custom_components/ha_aqara_devices/translations/ru.json
+++ b/custom_components/ha_aqara_devices/translations/ru.json
@@ -145,6 +145,19 @@
             "user_id_temporary_password": {
                 "name": "ID пользователя временного пароля"
             },
+            "lock_exception_alert": {
+                "name": "Предупреждение о неисправности замка"
+            },
+            "device_online_status": {
+                "name": "Статус устройства в сети",
+                "state": {
+                    "offline": "Не в сети",
+                    "online": "В сети"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Уровень сигнала Zigbee"
+            },
             "people_counting": {
                 "name": "Подсчёт людей"
             },

--- a/custom_components/ha_aqara_devices/translations/zh-Hans.json
+++ b/custom_components/ha_aqara_devices/translations/zh-Hans.json
@@ -172,6 +172,19 @@
             "user_id_temporary_password": {
                 "name": "临时密码用户 ID"
             },
+            "lock_exception_alert": {
+                "name": "锁异常告警"
+            },
+            "device_online_status": {
+                "name": "设备在线状态",
+                "state": {
+                    "offline": "离线",
+                    "online": "在线"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Zigbee 信号强度"
+            },
             "people_counting": {
                 "name": "人数统计"
             },

--- a/custom_components/ha_aqara_devices/translations/zh-Hant.json
+++ b/custom_components/ha_aqara_devices/translations/zh-Hant.json
@@ -172,6 +172,19 @@
             "user_id_temporary_password": {
                 "name": "臨時密碼使用者 ID"
             },
+            "lock_exception_alert": {
+                "name": "鎖異常警告"
+            },
+            "device_online_status": {
+                "name": "裝置線上狀態",
+                "state": {
+                    "offline": "離線",
+                    "online": "線上"
+                }
+            },
+            "zigbee_signal_strength": {
+                "name": "Zigbee 訊號強度"
+            },
             "people_counting": {
                 "name": "人數統計"
             },


### PR DESCRIPTION
## Summary

- Add `aqara.lock.acn002` as Aqara Smart Video Door Lock Xingyao (`全自动智能猫眼门锁 星耀`).
- Wire ACN002 locks into device discovery, coordinators, resource subscriptions, and SSE push handling.
- Reuse the existing A100 Pro door event / lock state / open method resources, and add ACN002 exception, online status, and Zigbee signal sensors.
- Initialize sensor options defensively so resources without enum options do not inherit stale option metadata or fail during state updates.
- Preserve existing coordinator data when the local bridge sends an SSE `snapshot`, because the bridge snapshot is a replay of recent events rather than a complete state dump.
- Trigger one delayed refresh after ACN002 entities are added so state is populated after Home Assistant restart without waiting for the next push event.

## Validation

- `git diff --check`
- `python3 -m compileall -q custom_components/ha_aqara_devices`
- Static assertions for ACN002 model registration, sensor setup, resource subscriptions, push handling, snapshot merge behavior, and delayed refresh wiring.
- Verified in a local ACN002 setup that lock-status, online-status, and Zigbee-signal entities load with values.
- Verified that subscribed ACN002 resource updates are delivered through the push path and reflected in Home Assistant state history.
- Verified that `door_event` behaves like event/diagnostic data and should not be treated as an authoritative current door-open state.

## Ready status

- ACN002 devices are discovered, entities are created, resource subscriptions and SSE updates are wired, snapshot events merge into existing coordinator data, and a delayed refresh fills initial state after restart.
- The supported scope is status reporting only. The ACN002 Open API resources observed during testing are read-only, and no supported remote lock/unlock write API was found.

## Caveats

- `open_door_method` and some exception sensors can remain `unknown` when Aqara has not reported those resources.
- Door open/closed state should not be inferred from `door_event`; use a dedicated contact sensor when current door state matters.
- Battery resource `3.19.85` appeared in `query.resource.info` for ACN002, but it did not return current values during testing, so no battery entity is exposed in this PR.

---

## 中文说明

### 摘要

- 为 Aqara 星耀门锁 / ACN002（`aqara.lock.acn002`，产品名：`全自动智能猫眼门锁 星耀`）增加 Home Assistant 只读状态接入。
- 新增 ACN002 型号识别，让集成能发现这类门锁设备。
- 复用 A100 Pro 已有的门锁状态、门事件、开门方式等资源定义，并补充 ACN002 的异常告警、在线状态和 Zigbee 信号强度。
- 将 ACN002 加入资源订阅和 RocketMQ bridge / SSE 推送处理，门锁状态变化可以实时进入 Home Assistant。
- 对 bridge 的 `snapshot` 做合并处理，避免不完整快照把已有字段覆盖成 `unknown`。
- ACN002 实体创建后增加一次延迟刷新，降低 HA 重启后实体长时间停留在 `unknown` 的概率。
- 对没有枚举选项的 sensor 做防御性初始化，避免无 `options` 的资源触发状态更新问题。

### 验证

- 已通过 `git diff --check`。
- 已通过 `python3 -m compileall -q custom_components/ha_aqara_devices`。
- 已做静态断言检查：ACN002 型号注册、sensor 创建、资源订阅、推送处理、snapshot 合并、延迟刷新都在。
- 已在本地 ACN002 测试环境中验证门锁状态、在线状态和 Zigbee 信号实体可以加载并返回值。
- 已验证 ACN002 订阅资源更新可以通过推送进入 Home Assistant，并写入状态历史。
- 已确认 `door_event` 更像事件/诊断数据，不应作为当前门开关状态的权威来源。

### 就绪状态

- ACN002 设备可以被发现，实体能创建，资源订阅和 SSE 推送已接通；snapshot 会合并到现有 coordinator 数据，重启后会再做一次延迟刷新补状态。
- 当前支持范围就是状态读取。测试到的 ACN002 Open API 资源都是只读资源，没有发现可用的远程上锁/开锁写入接口。

### 注意事项

- 当 Aqara 没有上报相关资源时，`open_door_method` 和部分异常传感器可能保持 `unknown`。
- `door_event` 不应推断为当前门开/关状态；需要当前门状态时应使用专用门磁/接触传感器。
- ACN002 的 `3.19.85` 电池资源能从 `query.resource.info` 中看到，但测试时没有返回当前值，所以本 PR 暂不暴露电池实体。